### PR TITLE
Add a .travis.yml file for continuous integration emacs 23, 24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,164 @@
+###
+### Notes
+###
+### Adapted from https://github.com/rolandwalker/emacs-travis/blob/master/.travis.yml
+###
+### The travis web interface may choke silently and fail to
+### update when there are issues with the .travis.yml file.
+###
+### The "travis-lint" command-line tool does not catch all
+### errors which may lead to silent failure.
+###
+### Shell-style comments in this file must have "#" as the
+### *first* character of the line.
+###
+
+###
+### language
+###
+
+# travis-lint no longer permits this value
+# language: emacs-lisp
+
+###
+### defining the build matrix
+###
+### ===>                                                       <===
+### ===> each variation in env/matrix will be built and tested <===
+### ===>                                                       <===
+###
+### variables under env/global are available to the build process
+### but don't cause the creation of a separate variation
+###
+
+env:
+  matrix:
+#   - EMACS=xemacs21
+#    - EMACS=emacs22
+    - EMACS=emacs23
+    - EMACS=emacs24
+    - EMACS=emacs-snapshot
+#  global:
+#    - SOME_TOKEN=some_value
+
+###
+### allowing build failures
+###
+
+matrix:
+  allow_failures:
+#   - env: EMACS=xemacs21
+    - env: EMACS=emacs22
+    - env: EMACS=emacs-snapshot
+
+###
+### limit build attempts to defined branches
+###
+### notes
+###
+### This controls which branches are built.
+###
+### You can also control which branches affect the web badge, by
+### appending "?branch=master,staging,production" to the end of the
+### image URL (replacing "master,staging,production" with a
+### comma-separated list of branches to be reflected in the badge).
+###
+#
+#  branches:
+#    only:
+#      - master
+#
+
+###
+### runtime initialization
+###
+### notes
+###
+### emacs22 is extracted manually from Ubuntu Maverick.
+###
+### emacs23 is the stock default, but is updated anyway to
+### a GUI-capable version, which will have certain additional
+### functions compiled in.
+###
+### emacs24 (current stable release) is obtained from the
+### cassou PPA: http://launchpad.net/~cassou/+archive/emacs
+###
+### emacs-snapshot (trunk) is obtained from the Ubuntu Emacs Lisp PPA:
+### https://launchpad.net/~ubuntu-elisp/+archive/ppa
+### For the emacs-snapshot build, bleeding-edge versions
+### of all test dependencies are also used.
+###
+
+#before_install:
+#  - git submodule --quiet update --init --recursive
+
+install:
+  - sudo apt-get -qq update && sudo apt-get -y install perl
+# - if [ "$EMACS" = 'xemacs21' ]; then
+#       sudo apt-get -qq update &&
+#       sudo apt-get -qq -f install &&
+#       sudo apt-get -qq install xemacs21-basesupport xemacs21-basesupport-el xemacs21-supportel xemacs21-support xemacs21-mulesupport-el xemacs21-mulesupport xemacs21-mule-canna-wnn xemacs21-mule-canna-wnn;
+#   fi
+  - if [ "$EMACS" = 'emacs22' ]; then
+        curl -Os http://security.ubuntu.com/ubuntu/pool/universe/e/emacs22/emacs22_22.2-0ubuntu9_i386.deb &&
+        curl -Os http://security.ubuntu.com/ubuntu/pool/universe/e/emacs22/emacs22-bin-common_22.2-0ubuntu9_i386.deb &&
+        curl -Os http://security.ubuntu.com/ubuntu/pool/universe/e/emacs22/emacs22-common_22.2-0ubuntu9_all.deb &&
+        curl -Os http://security.ubuntu.com/ubuntu/pool/universe/e/emacs22/emacs22-el_22.2-0ubuntu9_all.deb &&
+        curl -Os http://security.ubuntu.com/ubuntu/pool/universe/e/emacs22/emacs22-gtk_22.2-0ubuntu9_i386.deb &&
+        sudo apt-get -qq update &&
+        sudo apt-get -qq remove emacs emacs23-bin-common emacs23-common emacs23-nox &&
+        sudo apt-get -qq --fix-missing install install-info emacsen-common libjpeg62:i386 xaw3dg:i386 liblockfile1:i386 libasound2:i386 libgif4:i386 libncurses5:i386 libpng12-0:i386 libtiff4:i386 libxpm4:i386 libxft2:i386 libglib2.0-0:i386 libgtk2.0-0:i386 &&
+        sudo apt-get -qq -f install &&
+        sudo dpkg -i emacs22-common_22.2-0ubuntu9_all.deb emacs22-el_22.2-0ubuntu9_all.deb &&
+        sudo dpkg -i --force-depends emacs22-bin-common_22.2-0ubuntu9_i386.deb &&
+        sudo dpkg -i emacs22_22.2-0ubuntu9_i386.deb emacs22-gtk_22.2-0ubuntu9_i386.deb &&
+        sudo update-alternatives --set emacs22 /usr/bin/emacs22-gtk;
+    fi
+  - if [ "$EMACS" = 'emacs23' ]; then
+        sudo apt-get -qq update &&
+        sudo apt-get -qq -f install &&
+        sudo apt-get -qq install emacs23-gtk emacs23-el;
+    fi
+  - if [ "$EMACS" = 'emacs24' ]; then
+        sudo add-apt-repository -y ppa:cassou/emacs &&
+        sudo apt-get -qq update &&
+        sudo apt-get -qq -f install &&
+        sudo apt-get -qq install emacs24 emacs24-el;
+    fi
+  - if [ "$EMACS" = 'emacs-snapshot' ]; then
+        sudo add-apt-repository -y ppa:ubuntu-elisp/ppa &&
+        sudo apt-get -qq update &&
+        sudo apt-get -qq -f install &&
+        sudo apt-get -qq install emacs-snapshot &&
+        sudo apt-get -qq install emacs-snapshot-el;
+    fi
+
+#before_script:
+#  - if [ "$EMACS" = 'emacs-snapshot' ]; then
+#        make downloads-latest;
+#    else
+#        make downloads;
+#    fi
+
+###
+### the actual build/test command
+###
+
+script:
+  $EMACS --version && make EMACS="$EMACS"
+
+###
+### settings
+###
+
+#notifications:
+#  email: false
+
+#
+# Emacs
+#
+# Local Variables:
+# indent-tabs-mode: nil
+# coding: utf-8
+# End:
+#


### PR DESCRIPTION
This is based on (cargo culted from)
https://github.com/rolandwalker/emacs-travis/blob/master/.travis.yml.  Someone
will have to go to https://travis-ci.org/profile/ProofGeneral to enable Travis
for PG.  Do we want to require emacs-snapshot to succeed, or allow it to fail.