### PR TITLE
travis.yml for emacs 24.{3,4,5}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: emacs-lisp
+sudo: false
+
+env:
+  - EMACS_TARGET=emacs-21.4a
+  - EMACS_TARGET=emacs-22.1
+  - EMACS_TARGET=emacs-22.2
+  - EMACS_TARGET=emacs-22.3
+  - EMACS_TARGET=emacs-23.1
+  - EMACS_TARGET=emacs-23.2b
+  - EMACS_TARGET=emacs-23.3b
+  - EMACS_TARGET=emacs-23.4
+  - EMACS_TARGET=emacs-24.1
+  - EMACS_TARGET=emacs-24.2
+  - EMACS_TARGET=emacs-24.3
+  - EMACS_TARGET=emacs-24.4
+  - EMACS_TARGET=emacs-24.5
+  - EMACS_TARGET=emacs-git
+
+before_install:
+  - make -f Makefile.travis before_install
+
+install:
+  - make -f Makefile.travis install
+
+script:
+  - emacs --version
+  - make -f Makefile.travis script

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,6 @@ language: emacs-lisp
 sudo: false
 
 env:
-  - EMACS_TARGET=emacs-21.4a
-  - EMACS_TARGET=emacs-22.1
-  - EMACS_TARGET=emacs-22.2
-  - EMACS_TARGET=emacs-22.3
-  - EMACS_TARGET=emacs-23.1
-  - EMACS_TARGET=emacs-23.2b
-  - EMACS_TARGET=emacs-23.3b
-  - EMACS_TARGET=emacs-23.4
-  - EMACS_TARGET=emacs-24.1
-  - EMACS_TARGET=emacs-24.2
   - EMACS_TARGET=emacs-24.3
   - EMACS_TARGET=emacs-24.4
   - EMACS_TARGET=emacs-24.5

--- a/Makefile.travis
+++ b/Makefile.travis
@@ -1,0 +1,29 @@
+VERSIONS = 21.4a 22.1 22.2 22.3 23.1 23.2b 23.3b 23.4 24.1 24.2 24.3 24.4 24.5
+STABLE_TARGETS = $(addprefix prepare-emacs-,$(VERSIONS))
+
+.PHONY: prepare-emacs-24 prepare-emacs-git $(STABLE_TARGETS) \
+        prepare-emacs before_install install script
+
+$(STABLE_TARGETS):
+	curl -o /tmp/$(EMACS_TARGET).tar.gz "https://ftp.gnu.org/gnu/emacs/$(EMACS_TARGET).tar.gz"
+	mkdir /tmp/emacs-tmp
+	tar xzf /tmp/$(EMACS_TARGET).tar.gz -C /tmp/emacs-tmp
+	mv /tmp/emacs-tmp/* "/tmp/emacs" || (ls /tmp/*; exit 1)
+
+prepare-emacs-git:
+	git clone --depth=1 'http://git.sv.gnu.org/r/emacs.git' /tmp/emacs
+	cd /tmp/emacs && ./autogen.sh
+
+prepare-emacs: prepare-$(EMACS_TARGET)
+	cd /tmp/emacs && ./configure --prefix="$(HOME)" --without-all --with-x-toolkit=no --without-x --with-xml2 && make -j2 install
+
+before_install: prepare-emacs
+
+install:
+
+script:
+	make
+
+# Local Variables:
+# indent-tabs-mode: t
+# End:


### PR DESCRIPTION
This closes #27.  I found that no emacs before 24.3 builds on Travis.