### PR TITLE
Update numbering flag passed to texi2html

### DIFF
--- a/doc/Makefile.doc
+++ b/doc/Makefile.doc
@@ -18,7 +18,7 @@
 
 MAKE = make -f Makefile.doc 
 MAKEINFO = makeinfo
-TEXI2HTML = texi2html -expandinfo -number -split_chapter --noheader --css-include proofgen.css
+TEXI2HTML = texi2html -expandinfo -number-sections -split_chapter --noheader --css-include proofgen.css
 # `texinfo-tex' package contains texi2pdf
 TEXI2PDF = texi2pdf
 # `dviutils' package contains these useful utilities.


### PR DESCRIPTION
Fixes a bug with producing HTML documentation under recent (less than 5 years
old) versions of texi2html.

texi2html, [as of version 1.80](http://download-mirror.savannah.gnu.org/releases//texi2html/NEWS-1.80),
uses -number-sections instead of -number for the flag name.