### PR TITLE
Fix (next-undo-elt) to return a relevant undo element w.r.t (undo-delta)

### DIFF
--- a/generic/pg-user.el
+++ b/generic/pg-user.el
@@ -1273,7 +1273,11 @@ assuming the undo-in-region behavior will apply if ARG is non-nil."
 		     buffer-undo-list)))		 ; can be nil
     (if (or (null undo-list) (equal undo-list (list nil)))
 	nil				; there is clearly no undo elt
-      (while (eq (car undo-list) nil)
+      (while (and undo-list             ; to ensure it will terminate
+                  (let ((elt (car undo-list)))
+                    (not (and (consp elt)
+                              (or (stringp (car elt))
+                                  (integerp (car elt)))))))
 	(setq undo-list (cdr undo-list))) ; get the last undo record
       (if (and (eq last-command 'undo)
 	       (or (eq pending-undo-list t)


### PR DESCRIPTION
This a patch to fix #39

I have tested my branch only with GNU Emacs 24.3.1, so more testing is welcome.
Ref: https://github.com/ProofGeneral/PG/issues/39#issuecomment-230180627
Cc: @JasonGross @Matafou @cpitclaudel 
