### PR TITLE
Refer to Apple's operating system as macOS

### DIFF
--- a/COMPATIBILITY
+++ b/COMPATIBILITY
@@ -15,20 +15,20 @@ See below for notes about other operating systems.
 
 In the major 4.0 release ** XEmacs compatibility was dropped **
 
-Running on Mac OS X
+Running on macOS
 -------------------
 
 For tips, please see here:
 
    http://proofgeneral.inf.ed.ac.uk/wiki/PGEmacsOnMacOSX
 
-We recommend the 24.5 build of GNU Emacs, which builds natively on Mac
-OS X (based on the NextStep port).  Binaries are available at various
+We recommend the 24.5 build of GNU Emacs, which builds natively on macOS
+(based on the NextStep port).  Binaries are available at various
 websites (e.g., http://emacsformacosx.com), or you can build your own
 by compiling from the FSF CVS. See the Emacs Wiki at
 http://www.emacswiki.org/emacs/EmacsForMacOS for more.
 
-Note that Mac compatibility isn't thoroughly tested.  If you discover
+Note that macOS compatibility isn't thoroughly tested.  If you discover
 problems, please send a report and/or fix to the PG tracker.  Please
 add tips to the wiki page above.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Then add the following to your `.emacs`:
 (load "~/.emacs.d/lisp/PG/generic/proof-site")
 ```
 
-If Proof General complains about a version mismatch, make sure that the shell's `emacs` is indeed your usual Emacs. If not, run the Makefile again with an explicit path to Emacs. On Mac in particular you'll probably need something like
+If Proof General complains about a version mismatch, make sure that the shell's `emacs` is indeed your usual Emacs. If not, run the Makefile again with an explicit path to Emacs. On macOS in particular you'll probably need something like
 
 ```sh
 make clean; make EMACS=/Applications/Emacs.app/Contents/MacOS/Emacs


### PR DESCRIPTION
Starting with the latest version (10.12 "Sierra"), the operating system
is called macOS rather than Mac OS X.

Mac is technically the name of the hardware, not the operating system.