### PR TITLE
first version for quick compilation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,33 @@ and the PG Trac http://proofgeneral.inf.ed.ac.uk/trac
     - Using query-replace (or replace-string) in the processed region
       doesn't wrongly jump to the first match anymore.
 
+** Coq changes
+
+*** new menu Coq -> Auto Compilation for all background compilation options
+
+*** support for 8.5 quick compilation
+
+    See new menu Coq -> Auto Compilation. Select "no quick" as
+    long as you have not switched to "Proof using" to compile
+    without -quick. Select "quick no vio2vo" to use -quick
+    without vio2vo (and guess what "quick and vio2vo" means ;-),
+    select "ensure vo" to ensure a sound development. See the
+    option `coq-compile-quick' or the subsection "11.3.3 Quick
+    compilation and .vio Files" in the Coq reference manual.
+
+*** bug fixes
+    - avoid leaving partial files behind when compilation fails
+    - 123: Parallel background compliation fails to execute some
+      imports
+    - fix error in process filter: Cannot resize window
+    - 54 partially: Buffer coq-compile-response sometimes takes
+      over the whole window
+    - 75: Library more.v is required
+    - 70: Coq trunk + compile before require => « Invalid version
+      syntax: 'trunk' »
+    - 92: Compile before require from current directory failing
+      with 8.5
+
 * Changes of Proof General 4.4 from Proof General 4.3
 
 ** ProofGeneral has moved to GitHub!

--- a/coq/coq-abbrev.el
+++ b/coq/coq-abbrev.el
@@ -148,27 +148,54 @@ It was constructed with `proof-defstringset-fn'.")
      :style toggle
      :selected coq-double-hit-enable
      :help "Automatically send commands when terminator typed twiced quickly."]
-    ("Quick compilation mode"
+    ("Auto Compilation"
+     ["Compile Before Require"
+      coq-compile-before-require-toggle
+      :style toggle
+      :selected coq-compile-before-require
+      :help "Check dependencies of required modules and compile on the fly."]
+     ["Parallel background compilation"
+      coq-compile-parallel-in-background-toggle
+      :style toggle
+      :selected coq-compile-parallel-in-background
+      :active coq-compile-before-require
+      :help ,(concat "Compile parallel in background or "
+		    "sequentially with blocking ProofGeneral.")]
      ["no quick"
       (customize-set-variable 'coq-compile-quick 'no-quick)
       :style radio
       :selected (eq coq-compile-quick 'no-quick)
+      :active (and coq-compile-before-require
+		   coq-compile-parallel-in-background)
       :help "Compile without -quick but accept existion .vio's"]
      ["quick no vio2vo"
       (customize-set-variable 'coq-compile-quick 'quick-no-vio2vo)
       :style radio
       :selected (eq coq-compile-quick 'quick-no-vio2vo)
-      :help "Compile with -quick, accept existing .vo's"]
+      :active (and coq-compile-before-require
+		   coq-compile-parallel-in-background)
+      :help "Compile with -quick, accept existing .vo's, don't run vio2vo"]
      ["quick and vio2vo"
       (customize-set-variable 'coq-compile-quick 'quick-and-vio2vo)
       :style radio
       :selected (eq coq-compile-quick 'quick-and-vio2vo)
-      :help "Compile with -quick, accept existing .vo's, run vio2vo"]
+      :active (and coq-compile-before-require
+		   coq-compile-parallel-in-background)
+      :help "Compile with -quick, accept existing .vo's, run vio2vo later"]
      ["ensure vo"
       (customize-set-variable 'coq-compile-quick 'ensure-vo)
       :style radio
       :selected (eq coq-compile-quick 'ensure-vo)
-      :help "Ensure only vo's are used for consistency"])
+      :active (and coq-compile-before-require
+		   coq-compile-parallel-in-background)
+      :help "Ensure only vo's are used for consistency"]
+     ["Confirm External Compilation"
+      coq-confirm-external-compilation-toggle
+      :style toggle
+      :selected coq-confirm-external-compilation
+      :active (and coq-compile-before-require
+		   (not (equal coq-compile-command "")))
+      :help "Confirm external compilation command, see `coq-compile-command'."])
     ""
     ["Print..." coq-Print :help "With prefix arg (C-u): Set Printing All first"]
     ["Check..." coq-Check :help "With prefix arg (C-u): Set Printing All first"]

--- a/coq/coq-abbrev.el
+++ b/coq/coq-abbrev.el
@@ -148,6 +148,27 @@ It was constructed with `proof-defstringset-fn'.")
      :style toggle
      :selected coq-double-hit-enable
      :help "Automatically send commands when terminator typed twiced quickly."]
+    ("Quick compilation mode"
+     ["no quick"
+      (customize-set-variable 'coq-compile-quick 'no-quick)
+      :style radio
+      :selected (eq coq-compile-quick 'no-quick)
+      :help "Compile without -quick but accept existion .vio's"]
+     ["quick no vio2vo"
+      (customize-set-variable 'coq-compile-quick 'quick-no-vio2vo)
+      :style radio
+      :selected (eq coq-compile-quick 'quick-no-vio2vo)
+      :help "Compile with -quick, accept existing .vo's"]
+     ["quick and vio2vo"
+      (customize-set-variable 'coq-compile-quick 'quick-and-vio2vo)
+      :style radio
+      :selected (eq coq-compile-quick 'quick-and-vio2vo)
+      :help "Compile with -quick, accept existing .vo's, run vio2vo"]
+     ["ensure vo"
+      (customize-set-variable 'coq-compile-quick 'ensure-vo)
+      :style radio
+      :selected (eq coq-compile-quick 'ensure-vo)
+      :help "Ensure only vo's are used for consistency"])
     ""
     ["Print..." coq-Print :help "With prefix arg (C-u): Set Printing All first"]
     ["Check..." coq-Check :help "With prefix arg (C-u): Set Printing All first"]

--- a/coq/coq-compile-common.el
+++ b/coq/coq-compile-common.el
@@ -275,6 +275,14 @@ percentage of `coq-max-background-compilation-jobs'."
   :set 'coq-max-vio2vo-setter
   :group 'coq-auto-compile)
 
+(defcustom coq-compile-vio2vo-delay 2.5
+  "Delay in seconds for the vio2vo compilation.
+This delay helps to avoid running into a library inconsistency
+with 'quick-and-vio2vo, see Coq issue #5223."
+  :type 'number
+  :safe 'numberp
+  :group 'coq-auto-compile)
+
 (defcustom coq-compile-command ""
   "External compilation command. If empty ProofGeneral compiles itself.
 If unset (the empty string) ProofGeneral computes the dependencies of

--- a/coq/coq-compile-common.el
+++ b/coq/coq-compile-common.el
@@ -163,7 +163,7 @@ required library module and its dependencies are up-to-date. If not, they
 are compiled from the sources before the \"Require\" command is processed.
 
 This option can be set/reset via menu
-`Coq -> Settings -> Compile Before Require'."
+`Coq -> Auto Compilation -> Compile Before Require'."
   :type 'boolean
   :safe 'booleanp
   :group 'coq-auto-compile)
@@ -180,7 +180,7 @@ the background. The maximal number of parallel compilation jobs
 is set with `coq-max-background-compilation-jobs'.
 
 This option can be set/reset via menu
-`Coq -> Settings -> Compile Parallel In Background'."
+`Coq -> Auto Compilation -> Compile Parallel In Background'."
   :type 'boolean
   :safe 'booleanp
   :group 'coq-auto-compile
@@ -206,34 +206,43 @@ Use the default `no-quick', if you have not yet switched to
 ``Proof using''. Use `quick-no-vio2vo', if you want quick
 recompilation without producing .vo files. Value
 `quick-and-vio2vo' updates missing prerequisites with ``-quick''
-and starts vio2vo conversion on a subset of the availables cores
-when the quick recompilation finished (see also
-`coq-compile-vio2vo-percentage'). Note that all the previously
-described modes might load .vio files and that you therefore
-might not notice certain universe inconsitencies. Finally, use
-`ensure-vo' for only importing .vo files with complete universe
-checks.
+and starts vio2vo conversion on a subset of the availables
+cores (see `coq-compile-vio2vo-percentage') when the quick
+recompilation finished (but see below for a .vio .vo
+incompatibility caveat). Note that all the previously described
+modes might load .vio files and that you therefore might not
+notice certain universe inconsistencies. Finally, use `ensure-vo'
+for only importing .vo files with complete universe checks.
 
 Detailed description of the 4 modes:
+
 no-quick         Compile outdated prerequisites without ``-quick'',
                  producing .vo files, but don't compile prerequisites
                  for which an up-to-date .vio file exists. Delete
                  or overwrite outdated .vo files.
+
 quick-no-vio2vo  Compile outdated prerequisites with ``-quick'',
                  producing .vio files, but don't compile prerequisites
                  for which an up-to-date .vo file exists. Delete
                  or overwrite outdated .vio files.
-quick-and-vio2vo Not yet supported, currently the same as `quick-no-vio2vo'.
-                 Same as `quick-no-vio2vo', but start vio2vo processes
-                 after the last require command has been processed
+
+quick-and-vio2vo Same as `quick-no-vio2vo', but start vio2vo processes
+                 after the last ``Require'' command has been processed
                  to convert the vio dependencies into vo files. With this
                  mode you might see asynchronous errors from vio2vo
                  compilation while you are processing stuff far below the
                  last require. vio2vo compilation is done on a subset of
                  the available cores, see `coq-compile-vio2vo-percentage'.
-ensure-vo        Delete all .vio files for prerequisites and recompile
-                 without ``-quick'' as necessary. This setting is the
-                 only one that esures soundness."
+
+                 Warning: This mode does only work when you process require
+                 commands in batches. Slowly single-stepping through require's
+                 might lead to inconsistency errors when loading some
+                 libraries, see Coq issue #5223.
+
+ensure-vo        Ensure that all library dependencies are present as .vo
+                 files and delete outdated .vio files or .vio files that
+                 are more recent than the corresponding .vo file. This
+                 setting is the only one that ensures soundness."
   :type
   '(radio
     (const :tag "don't use -quick but accept existing vio files" no-quick)

--- a/coq/coq-compile-common.el
+++ b/coq/coq-compile-common.el
@@ -454,11 +454,10 @@ modules are matched separately with `coq-require-id-regexp'")
 (defvar coq-compile-history nil
   "History of external Coq compilation commands.")
 
-(defvar coq-compile-response-buffer "*coq-compile-response*"
+(defvar coq--compile-response-buffer "*coq-compile-response*"
   "Name of the buffer to display error messages from coqc and coqdep.")
 
-
-(defvar coq-debug-auto-compilation nil
+(defvar coq--debug-auto-compilation nil
   "*Display more messages during compilation")
 
 
@@ -509,14 +508,14 @@ compiled with ``-quick'' or not."
     (eq (compare-strings coq-library-directory 0 nil
                          lib-obj-file 0 (length coq-library-directory))
         t)
-    (if coq-debug-auto-compilation
+    (if coq--debug-auto-compilation
         (message "Ignore lib file %s" lib-obj-file))
     t)
    (if (some
           (lambda (dir-regexp) (string-match dir-regexp lib-obj-file))
           coq-compile-ignored-directories)
        (progn
-         (if coq-debug-auto-compilation
+         (if coq--debug-auto-compilation
              (message "Ignore %s" lib-obj-file))
          t)
      nil)))
@@ -556,34 +555,34 @@ Changes the suffix from .vio to .vo. VO-OBJ-FILE must have a .vo suffix."
   (span-set-property span 'coq-locked-ancestors ()))
 
 
-;;; manage coq-compile-response-buffer
+;;; manage coq--compile-response-buffer
 
 (defun coq-compile-display-error (command error-message display)
-  "Display COMMAND and ERROR-MESSAGE in `coq-compile-response-buffer'.
-If needed, reinitialize `coq-compile-response-buffer'. Then
+  "Display COMMAND and ERROR-MESSAGE in `coq--compile-response-buffer'.
+If needed, reinitialize `coq--compile-response-buffer'. Then
 display COMMAND and ERROR-MESSAGE."
-  (unless (buffer-live-p coq-compile-response-buffer)
+  (unless (buffer-live-p coq--compile-response-buffer)
     (coq-init-compile-response-buffer))
   (let ((inhibit-read-only t))
-    (with-current-buffer coq-compile-response-buffer
+    (with-current-buffer coq--compile-response-buffer
       (insert command "\n" error-message)))
   (when display
     (coq-display-compile-response-buffer)))
 
 (defun coq-init-compile-response-buffer (&optional command)
   "Initialize the buffer for the compilation output.
-If `coq-compile-response-buffer' exists, empty it. Otherwise
-create a buffer with name `coq-compile-response-buffer', put
+If `coq--compile-response-buffer' exists, empty it. Otherwise
+create a buffer with name `coq--compile-response-buffer', put
 it into `compilation-mode' and store it in
-`coq-compile-response-buffer' for later use. Argument COMMAND is
+`coq--compile-response-buffer' for later use. Argument COMMAND is
 the command whose output will appear in the buffer."
-  (let ((buffer-object (get-buffer coq-compile-response-buffer)))
+  (let ((buffer-object (get-buffer coq--compile-response-buffer)))
     (if buffer-object
         (let ((inhibit-read-only t))
           (with-current-buffer buffer-object
             (erase-buffer)))
       (setq buffer-object
-            (get-buffer-create coq-compile-response-buffer))
+            (get-buffer-create coq--compile-response-buffer))
       (with-current-buffer buffer-object
         (compilation-mode)
 	;; read-only-mode makes compilation fail if some messages need
@@ -601,18 +600,18 @@ the command whose output will appear in the buffer."
 	  (insert command "\n"))))))
 
 (defun coq-display-compile-response-buffer ()
-  "Display the errors in `coq-compile-response-buffer'."
-  (with-current-buffer coq-compile-response-buffer
+  "Display the errors in `coq--compile-response-buffer'."
+  (with-current-buffer coq--compile-response-buffer
     ;; fontification enables the error messages
     (let ((font-lock-verbose nil)) ; shut up font-lock messages
       (font-lock-fontify-buffer)))
   ;; Make it so the next C-x ` will use this buffer.
-  (setq next-error-last-buffer (get-buffer coq-compile-response-buffer))
-  (proof-display-and-keep-buffer coq-compile-response-buffer 1 t)
+  (setq next-error-last-buffer (get-buffer coq--compile-response-buffer))
+  (proof-display-and-keep-buffer coq--compile-response-buffer 1 t)
   ;; Partial fix for #54: ensure that the compilation response
   ;; buffer is not in a dedicated window.
   (mapc (lambda (w) (set-window-dedicated-p w nil))
-      (get-buffer-window-list coq-compile-response-buffer nil t)))
+      (get-buffer-window-list coq--compile-response-buffer nil t)))
 
 
 ;;; enable next-error to find vio2vo errors

--- a/coq/coq-compile-common.el
+++ b/coq/coq-compile-common.el
@@ -136,6 +136,18 @@ SYMBOL should be 'coq-max-background-compilation-jobs"
   (setq coq--internal-max-jobs new-value)
   (coq-set-max-vio2vo-jobs))
 
+(defun coq-compile-quick-setter (symbol new-value)
+  ":set function for `coq-compile-quick' for pre 8.5 compatibility.
+Ignore any quick setting for Coq versions before 8.5."
+  (cond
+   ((or (eq new-value 'ensure-vo) (eq new-value 'no-quick))
+    t)
+   ((coq--pre-v85)
+    (message "Ignore coq-compile-quick setting %s for Coq before 8.5"
+	     new-value)
+    (setq new-value 'no-quick)))
+  (set symbol new-value))
+
 
 ;;; user options and variables
 
@@ -179,20 +191,28 @@ This option can be set/reset via menu
 
 (defcustom coq-compile-quick 'no-quick
   "Control quick compilation, vio2vo and vio/vo files auto compilation.
-This option controls whether ``-quick'' is used for parallel background
-compilation and whether up-date .vo or .vio files are used or deleted.
+This option controls whether ``-quick'' is used for parallel
+background compilation and whether up-date .vo or .vio files are
+used or deleted. Please use the customization system to change
+this option to ensure that any ``-quick'' setting is ignored for
+Coq before 8.5.
 
-Note that ``-quick'' can be noticebly slower when your sources do not
-declare section variables with ``Proof using''. Use the default `no-quick',
-if you have not yet switched to ``Proof using''. Use `quick-no-vio2vo',
-if you want quick recompilation without producing .vo files. Value
-`quick-and-vio2vo' updates missing prerequisites with ``-quick'' and
-starts vio2vo conversion on a subset of the availables cores when the
-quick recompilation finished (see also `coq-compile-vio2vo-percentage').
-Note that all the previously described modes might load .vio files and
-that you therefore might not notice certain universe inconsitencies.
-Finally, use `ensure-vo' for only importing .vo files with complete
-universe checks.
+Note that ``-quick'' can be noticebly slower when your sources do
+not declare section variables with ``Proof using''. Note that
+even if you do declare section variables, ``-quick'' is typically
+slower on small files.
+
+Use the default `no-quick', if you have not yet switched to
+``Proof using''. Use `quick-no-vio2vo', if you want quick
+recompilation without producing .vo files. Value
+`quick-and-vio2vo' updates missing prerequisites with ``-quick''
+and starts vio2vo conversion on a subset of the availables cores
+when the quick recompilation finished (see also
+`coq-compile-vio2vo-percentage'). Note that all the previously
+described modes might load .vio files and that you therefore
+might not notice certain universe inconsitencies. Finally, use
+`ensure-vo' for only importing .vo files with complete universe
+checks.
 
 Detailed description of the 4 modes:
 no-quick         Compile outdated prerequisites without ``-quick'',
@@ -222,6 +242,7 @@ ensure-vo        Delete all .vio files for prerequisites and recompile
     (const :tag "ensure vo compilation, delete vio files" ensure-vo))
   :safe (lambda (v) (member v '(no-quick quick-no-vio2vo
 					 quick-and-vio2vo ensure-vo)))
+  :set 'coq-compile-quick-setter
   :group 'coq-auto-compile)
 
 (defun coq-compile-prefer-quick ()

--- a/coq/coq-compile-common.el
+++ b/coq/coq-compile-common.el
@@ -389,9 +389,10 @@ modules are matched separately with `coq-require-id-regexp'")
 
 (defun time-less-or-equal (time-1 time-2)
   "Return `t' if time value time-1 is earlier or equal to time-2.
-A time value is a list of two integers as returned by `file-attributes'.
-The first integer contains the upper 16 bits and the second the lower
-16 bits of the time."
+A time value is a list of two, three or four integers of the
+form (high low micro pico) as returned by `file-attributes' or
+'current-time'. First element high contains the upper 16 bits and
+the second low the lower 16 bits of the time."
   (not (time-less-p time-2 time-1)))
 
 (defun coq-max-dep-mod-time (dep-mod-times)

--- a/coq/coq-compile-common.el
+++ b/coq/coq-compile-common.el
@@ -18,6 +18,7 @@
 
 (eval-when (compile)
   ;;(defvar coq-pre-v85 nil)
+  (require 'compile)
   (defvar coq-confirm-external-compilation nil); defpacustom
   (defvar coq-compile-parallel-in-background nil) ; defpacustom
   (proof-ready-for-assistant 'coq))     ; compile for coq
@@ -612,6 +613,30 @@ the command whose output will appear in the buffer."
   ;; buffer is not in a dedicated window.
   (mapc (lambda (w) (set-window-dedicated-p w nil))
       (get-buffer-window-list coq-compile-response-buffer nil t)))
+
+
+;;; enable next-error to find vio2vo errors
+;;
+;; compilation-error-regexp-alist-alist is an alist mapping symbols to
+;; what is expected for compilation-error-regexp-alist. This is
+;; element of the form (REGEXP FILE [LINE COLUMN TYPE HYPERLINK
+;; HIGHLIGHT...]). If REGEXP matches, the FILE'th subexpression gives
+;; the file name, and the LINE'th subexpression gives the line number.
+;; The COLUMN'th subexpression gives the column number on that line,
+;; see the documentation of compilation-error-regexp-alist.
+;;
+;; Need to wrap adding the vio2vo error regex in eval-after-load,
+;; because compile is loaded on demand and might not be present when
+;; the user visits the first Coq file.
+
+(eval-after-load 'compile
+  '(progn
+     (push
+      '(coq-vio2vo
+	"File \\(.*\\): proof of [^:]*\\(: chars \\([0-9]*\\)-\\([0-9]*\\)\\)?"
+	1 nil 3)
+      compilation-error-regexp-alist-alist)
+     (push 'coq-vio2vo compilation-error-regexp-alist)))
 
 
 ;;; save some buffers

--- a/coq/coq-compile-common.el
+++ b/coq/coq-compile-common.el
@@ -392,8 +392,7 @@ modules are matched separately with `coq-require-id-regexp'")
 A time value is a list of two integers as returned by `file-attributes'.
 The first integer contains the upper 16 bits and the second the lower
 16 bits of the time."
-  (or (time-less-p time-1 time-2)
-      (equal time-1 time-2)))
+  (not (time-less-p time-2 time-1)))
 
 (defun coq-max-dep-mod-time (dep-mod-times)
   "Return the maximum in DEP-MOD-TIMES.

--- a/coq/coq-par-compile.el
+++ b/coq/coq-par-compile.el
@@ -888,7 +888,7 @@ therefore delete a file if it might be in the way."
        (if vo-obj-time (time-less-p vo-obj-time src-time) "-")
        (if vio-obj-time (time-less-p vio-obj-time src-time) "-")
        (if vo-obj-time (coq-par-time-less vo-obj-time dep-time) "-")
-       (if vio-obj-time (coq-par-time-less-p vio-obj-time dep-time) "-")))
+       (if vio-obj-time (coq-par-time-less vio-obj-time dep-time) "-")))
     ;; Compute first the max of vo-obj-time and vio-obj-time and remember
     ;; which of both is newer. This is only meaningful if at least one of
     ;; the .vo or .vio file exists.
@@ -906,8 +906,10 @@ therefore delete a file if it might be in the way."
     ;; Decide if and what to compile.
     (if (or (eq dep-time 'just-compiled) ; a dep has been just compiled
 	    (and (not vo-obj-time) (not vio-obj-time)) ; no obj exists
-	    (time-less-p max-obj-time src-time) ; src is younger than any obj
-	    (time-less-p max-obj-time dep-time)) ; dep is younger than any obj
+	    ;; src younger than any obj?
+	    (time-less-or-equal max-obj-time src-time)
+	    ;; dep younger than any obj?
+	    (time-less-or-equal max-obj-time dep-time))
 	;; compilation is definitely needed
 	(progn
 	  (setq result t)
@@ -963,9 +965,9 @@ therefore delete a file if it might be in the way."
 	      (put job 'required-obj-file vio-file)
 	      (put job 'obj-mod-time vio-obj-time)
 	      (when (and vo-obj-time
-			 (or (time-less-p vo-obj-time src-time)
+			 (or (time-less-or-equal vo-obj-time src-time)
 			     ;; dep-time is neither nil nor 'just-compiled here
-			     (time-less-p vo-obj-time dep-time)))
+			     (time-less-or-equal vo-obj-time dep-time)))
 		(setq file-to-delete vo-file))
 	      (when coq-debug-auto-compilation
 		(message "%s: vio up-to-date; delete %s"
@@ -974,9 +976,9 @@ therefore delete a file if it might be in the way."
 	  (put job 'required-obj-file vo-file)
 	  (put job 'obj-mod-time vo-obj-time)
 	  (when (and vio-obj-time
-		     (or (time-less-p vio-obj-time src-time)
+		     (or (time-less-or-equal vio-obj-time src-time)
 			 ;; dep-time is neither nil nor 'just-compiled here
-			 (time-less-p vio-obj-time dep-time)))
+			 (time-less-or-equal vio-obj-time dep-time)))
 	    (setq file-to-delete vio-file))
 	  (when coq-debug-auto-compilation
 	    (message "%s: vo up-to-date 2; delete %s"

--- a/coq/coq-par-test.el
+++ b/coq/coq-par-test.el
@@ -35,12 +35,12 @@
     ((src dep vio vo)
      (no-quick           nil            nil       vio)
      (quick              nil            nil       vio)
-     (ensure-vo          nil            vio       vo ))
+     (ensure-vo          nil            nil       vo ))
 
     ((src vo dep vio)    
      (no-quick           nil            vo        vio)
      (quick              nil            vo        vio)
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     ((src vo vio dep)
      (no-quick           t              vio       vo )
@@ -61,7 +61,7 @@
     ((dep src vio vo)
      (no-quick           nil            nil       vio)
      (quick              nil            nil       vio)
-     (ensure-vo          nil            vio       vo ))
+     (ensure-vo          nil            nil       vo ))
 
     ((dep src vo vio)
      (no-quick           nil            nil       vo )
@@ -76,7 +76,7 @@
     ((dep vo src vio)
      (no-quick           nil            vo        vio)
      (quick              nil            vo        vio)
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     ((dep vio vo src)
      (no-quick           t              vio       vo )
@@ -91,7 +91,7 @@
     ((vo src dep vio)
      (no-quick           nil            vo        vio)
      (quick              nil            vo        vio)
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     ;; present files   | compilation? | delete | 'req-obj-file
     ((vo src vio dep)
@@ -102,7 +102,7 @@
     ((vo dep src vio)
      (no-quick           nil            vo       vio )
      (quick              nil            vo       vio )
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     ((vo dep vio src)
      (no-quick           t              vio       vo )
@@ -188,7 +188,7 @@
     ((src dep vio)
      (no-quick           nil            nil      vio )
      (quick              nil            nil      vio )
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     ((src vio dep)
      (no-quick           t             vio       vo  )
@@ -198,7 +198,7 @@
     ((dep src vio)
      (no-quick           nil           nil       vio )
      (quick              nil           nil       vio )
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     ((dep vio src)
      (no-quick           t             vio       vo  )
@@ -226,12 +226,12 @@
     ((src vio vo)
      (no-quick           nil            nil       vio)
      (quick              nil            nil       vio)
-     (ensure-vo          nil            vio       vo ))
+     (ensure-vo          nil            nil       vo ))
 
     ((vo src vio)
      (no-quick           nil            vo       vio )
      (quick              nil            vo       vio )
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     ((vo vio src)
      (no-quick           t              vio      vo  )
@@ -278,7 +278,7 @@
     ((src vio)
      (no-quick           nil            nil      vio )
      (quick              nil            nil      vio )
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     ((vio src)
      (no-quick           t              vio      vo  )
@@ -306,7 +306,7 @@
     (((src vo dep) vio)
      (no-quick           nil            vo       vio )
      (quick              nil            vo       vio )
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     ((vio (src vo dep))
      (no-quick           t              vio      vo  )
@@ -357,8 +357,8 @@
 
     (((src dep) (vo vio))
      ;; could also use the vio as 'req-obj-file in the first 2 cases here
-     (no-quick           nil            nil       vio)
-     (quick              nil            nil       vio)
+     (no-quick           nil            nil       vo )
+     (quick              nil            nil       vo )
      (ensure-vo          nil            vio       vo ))
 
     (((vo vio) (src dep))
@@ -381,7 +381,7 @@
     (((src vo) dep vio)
      (no-quick           nil            vo        vio)
      (quick              nil            vo        vio)
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     (((src vo) vio dep)
      (no-quick           t              vio       vo )
@@ -391,7 +391,7 @@
     ((dep (src vo) vio)
      (no-quick           nil            vo        vio)
      (quick              nil            vo        vio)
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     ((dep vio (src vo))
      (no-quick           t              vio       vo )
@@ -417,12 +417,12 @@
     (((src dep) vio vo)
      (no-quick           nil            nil       vio)
      (quick              nil            nil       vio)
-     (ensure-vo          nil            vio       vo ))
+     (ensure-vo          nil            nil       vo ))
 
     ((vo (src dep) vio)
      (no-quick           nil            vo        vio)
      (quick              nil            vo        vio)
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     ((vo vio (src dep))
      (no-quick           t              vio       vo )
@@ -473,7 +473,7 @@
     (((vo dep) src vio)
      (no-quick           nil            vo       vio )
      (quick              nil            vo       vio )
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     (((vo dep) vio src)
      (no-quick           t              vio       vo )
@@ -483,7 +483,7 @@
     ((src (vo dep) vio)
      (no-quick           nil            vo        vio)
      (quick              nil            vo        vio)
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     ((src vio (vo dep))
      (no-quick           t              vio       vo )
@@ -518,8 +518,8 @@
 
     ((src dep (vo vio))
      ;; could also use the vio as 'req-obj-file in the first 2 cases here
-     (no-quick           nil            nil       vio)
-     (quick              nil            nil       vio)
+     (no-quick           nil            nil       vo )
+     (quick              nil            nil       vo )
      (ensure-vo          nil            vio       vo ))
 
     ((dep (vo vio) src)
@@ -529,8 +529,8 @@
 
     ((dep src (vo vio))
      ;; could also use the vio as 'req-obj-file in the first 2 cases here
-     (no-quick           nil            nil       vio)
-     (quick              nil            nil       vio)
+     (no-quick           nil            nil       vo )
+     (quick              nil            nil       vo )
      (ensure-vo          nil            vio       vo ))
 
     (((dep vio) src vo)
@@ -611,7 +611,7 @@
     (((src dep) vio)
      (no-quick           nil           nil       vio )
      (quick              nil           nil       vio )
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     ((vio (src dep))
      (no-quick           t              vio       vo )
@@ -657,7 +657,7 @@
     (((src vo) vio)
      (no-quick           nil            vo       vio )
      (quick              nil            vo       vio )
-     (ensure-vo          t              vio       vo ))
+     (ensure-vo          t              nil       vo ))
 
     ;; present files   | compilation? | delete | 'req-obj-file
     ((vio (src vo))
@@ -672,8 +672,8 @@
 
     ((src (vio vo))
      ;; could also use the vio as 'req-obj-file in the first 2 cases here
-     (no-quick           nil            nil       vio)
-     (quick              nil            nil       vio)
+     (no-quick           nil            nil       vo )
+     (quick              nil            nil       vo )
      (ensure-vo          nil            vio       vo ))
 
     ;; 2 files with identical time stamp out of 2 files

--- a/coq/coq-par-test.el
+++ b/coq/coq-par-test.el
@@ -1,0 +1,558 @@
+;; coq-par-test.el --- tests for parallel compilation
+;; Copyright (C) 2016 Hendrik Tews
+;; Authors: Hendrik Tews
+;; License:     GPL (GNU GENERAL PUBLIC LICENSE)
+;; Maintainer: Hendrik Tews <hendrik@askra.de>
+;;
+;;; Commentary:
+;;
+;; This file file contains tests for `coq-par-job-needs-compilation'.
+;; It specifies for all combinations of `coq-compile-quick', existing
+;; files and relative file ages the required result and side effects
+;; of `coq-par-job-needs-compilation'.
+;;
+;; Run the tests with
+;; emacs -batch -L . -L ../generic -L ../lib -load coq-par-test.el
+;;
+;;; TODO:
+;;
+;; - integrate into PG build and test(?) system
+;; - add tests for files with identical time stamps
+
+
+(require 'coq-par-compile)
+
+(defconst coq-par-job-needs-compilation-tests
+  ;; for documentation see the doc string following the init value
+  '(
+    ;; present files   | compilation? | delete | 'req-obj-file | 'obj-mod-t
+    ;; ====================================================================
+    ;; all of src dep vo vio present
+    ((src dep vo vio)
+     (no-quick           nil            nil       vio            vio)
+     (quick              nil            nil       vio            vio)
+     (ensure-vo          nil            vio       vo             vo))
+
+    ((src dep vio vo)
+     (no-quick           nil            nil       vo             vo  )
+     (quick              nil            nil       vo             vo  )
+     (ensure-vo          nil            vio       vo             vo  ))
+
+    ((src vo dep vio)    
+     (no-quick           nil            vo        vio            vio )
+     (quick              nil            vo        vio            vio )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((src vo vio dep)
+     (no-quick           t              vio       vo             nil )
+     (quick              t              vo        vio            nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((src vio dep vo)
+     (no-quick           nil            vio       vo             vo  )
+     (quick              nil            vio       vo             vo  )
+     (ensure-vo          nil            vio       vo             vo  ))
+
+    ((src vio vo dep)
+     (no-quick           t              vio       vo             nil )
+     (quick              t              vo        vio            nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ;; present files   | compilation? | delete | 'req-obj-file | 'obj-mod-t
+    ((dep src vio vo)
+     (no-quick           nil            nil       vo             vo  )
+     (quick              nil            nil       vo             vo  )
+     (ensure-vo          nil            vio       vo             vo  ))
+
+    ((dep src vo vio)
+     (no-quick           nil            nil       vio            vio )
+     (quick              nil            nil       vio            vio )
+     (ensure-vo          nil            vio       vo             vo  ))
+
+    ((dep vo vio src)
+     (no-quick           t              vio       vo             nil )
+     (quick              t              vo        vio            nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((dep vo src vio)
+     (no-quick           nil            vo        vio            vio )
+     (quick              nil            vo        vio            vio )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((dep vio vo src)
+     (no-quick           t              vio       vo             nil )
+     (quick              t              vo        vio            nil )
+     (ensure-vo          t              vio       vo             nil  ))
+
+    ((dep vio src vo)
+     (no-quick           nil            vio       vo             vo  )
+     (quick              nil            vio       vo             vo  )
+     (ensure-vo          nil            vio       vo             vo  ))
+
+    ((vo src dep vio)
+     (no-quick           nil            vo        vio            vio )
+     (quick              nil            vo        vio            vio )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ;; present files   | compilation? | delete | 'req-obj-file | 'obj-mod-t
+    ((vo src vio dep)
+     (no-quick           t              vio       vo             nil )
+     (quick              t              vo        vio            nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((vo dep src vio)
+     (no-quick           nil            vo       vio             vio )
+     (quick              nil            vo       vio             vio )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((vo dep vio src)
+     (no-quick           t              vio       vo             nil )
+     (quick              t              vo        vio            nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((vo vio src dep)
+     (no-quick           t              vio      vo              nil )
+     (quick              t              vo       vio             nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((vo vio dep src)
+     (no-quick           t              vio      vo              nil )
+     (quick              t              vo       vio             nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((vio src vo dep)
+     (no-quick           t              vio      vo              nil )
+     (quick              t              vo       vio             nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((vio src dep vo)
+     (no-quick           nil            vio      vo              vo  )
+     (quick              nil            vio      vo              vo  )
+     (ensure-vo          nil            vio       vo             vo  ))
+
+    ((vio dep vo src)
+     (no-quick           t              vio      vo              nil )
+     (quick              t              vo       vio             nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ;; present files   | compilation? | delete | 'req-obj-file | 'obj-mod-t
+    ((vio dep src vo)
+     (no-quick           nil            vio      vo              vo  )
+     (quick              nil            vio      vo              vo  )
+     (ensure-vo          nil            vio       vo             vo  ))
+
+    ((vio vo dep src)
+     (no-quick           t              vio      vo              nil )
+     (quick              t              vo       vio             nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((vio vo src dep)
+     (no-quick           t              vio      vo              nil )
+     (quick              t              vo       vio             nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+
+    ;; only src dep vo present
+    ((src dep vo)
+     (no-quick           nil            nil      vo              vo  )
+     (quick              nil            nil      vo              vo  )
+     (ensure-vo          nil            nil      vo              vo  ))
+
+    ((src vo dep)
+     (no-quick           t              nil      vo              nil )
+     (quick              t              vo       vio             nil )
+     (ensure-vo          t              nil      vo              nil ))
+
+    ((dep src vo)
+     (no-quick           nil            nil      vo              vo  )
+     (quick              nil            nil      vo              vo  )
+     (ensure-vo          nil            nil      vo              vo  ))
+
+    ((dep vo src)
+     (no-quick           t              nil      vo              nil )
+     (quick              t              vo       vio             nil )
+     (ensure-vo          t              nil      vo              nil ))
+
+    ((vo src dep)
+     (no-quick           t              nil      vo              nil )
+     (quick              t              vo       vio             nil )
+     (ensure-vo          t              nil      vo              nil ))
+
+    ((vo dep src)
+     (no-quick           t              nil      vo              nil )
+     (quick              t              vo       vio             nil )
+     (ensure-vo          t              nil      vo              nil ))
+
+
+    ;; present files   | compilation? | delete | 'req-obj-file | 'obj-mod-t
+    ;; only src dep vio present
+    ((src dep vio)
+     (no-quick           nil            nil      vio             vio )
+     (quick              nil            nil      vio             vio )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((src vio dep)
+     (no-quick           t             vio       vo              nil )
+     (quick              t             nil       vio             nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((dep src vio)
+     (no-quick           nil           nil       vio             vio )
+     (quick              nil           nil       vio             vio )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((dep vio src)
+     (no-quick           t             vio       vo              nil )
+     (quick              t             nil       vio             nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((vio src dep)
+     (no-quick           t             vio       vo              nil )
+     (quick              t             nil       vio             nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((vio dep src)
+     (no-quick           t             vio       vo              nil )
+     (quick              t             nil       vio             nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+
+    ;; present files   | compilation? | delete | 'req-obj-file | 'obj-mod-t
+    ;; only src vo vio present
+    ((src vo vio)
+     (no-quick           nil            nil      vio             vio )
+     (quick              nil            nil      vio             vio )
+     (ensure-vo          nil            vio       vo             vo  ))
+
+    ((src vio vo)
+     (no-quick           nil            nil      vo              vo  )
+     (quick              nil            nil      vo              vo  )
+     (ensure-vo          nil            vio       vo             vo  ))
+
+    ((vo src vio)
+     (no-quick           nil            vo       vio             vio )
+     (quick              nil            vo       vio             vio )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((vo vio src)
+     (no-quick           t              vio      vo              nil )
+     (quick              t              vo       vio             nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((vio src vo)
+     (no-quick           nil            vio      vo              vo  )
+     (quick              nil            vio      vo              vo  )
+     (ensure-vo          nil            vio      vo              vo  ))
+
+    ((vio vo src)
+     (no-quick           t              vio      vo              nil )
+     (quick              t              vo       vio             nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+
+    ;; present files   | compilation? | delete | 'req-obj-file | 'obj-mod-t
+    ;; only src dep present
+    ((src dep)
+     (no-quick           t              nil      vo              nil )
+     (quick              t              nil      vio             nil )
+     (ensure-vo          t              nil      vo              nil ))
+
+    ((dep src)
+     (no-quick           t              nil      vo              nil )
+     (quick              t              nil      vio             nil )
+     (ensure-vo          t              nil      vo              nil ))
+
+
+    ;; only src vo present
+    ((src vo)
+     (no-quick           nil            nil      vo              vo  )
+     (quick              nil            nil      vo              vo  )
+     (ensure-vo          nil            nil      vo              vo  ))
+
+    ((vo src)
+     (no-quick           t              nil      vo              nil )
+     (quick              t              vo       vio             nil )
+     (ensure-vo          t              nil      vo              nil ))
+
+
+    ;; only src vio present
+    ((src vio)
+     (no-quick           nil            nil      vio             vio )
+     (quick              nil            nil      vio             vio )
+     (ensure-vo          t              vio       vo             nil ))
+
+    ((vio src)
+     (no-quick           t              vio      vo              nil )
+     (quick              t              nil      vio             nil )
+     (ensure-vo          t              vio       vo             nil ))
+
+
+    ;; only src present
+    ((src)
+     (no-quick           t              nil      vo              nil )
+     (quick              t              nil      vio             nil )
+     (ensure-vo          t              nil      vo              nil ))
+    )
+  "Test and result specification for `coq-par-job-needs-compilation'.
+
+List of tests. A test is a list of 4 elements. The first element,
+a list, specifies the existing files and their relative age. In
+there, `src' stands for the source (x.v) file, `dep' for
+a (already compiled) dependency (dep.vo or dep.vio), `vo' for the
+.vo file (x.vo) and `vio' for the .vio file (x.vio). A label in
+the list denotes an existing file, a missing label a missing
+file. The first element is the oldest file, the last element the
+newest file.
+
+Elements 2-4 of a test specify the results and side effects of
+`coq-par-job-needs-compilation' for all setting of
+`coq-compile-quick' on the file configuration described in
+element 1. The options `quick-no-vio2vo' and `quick-and-vio2vo'
+are specified together with label `quick'. Each result and side
+effect specification (also called a variant in the source code
+below) is itself a list of 5 elements. Element 1 is the value for
+`coq-compile-quick', where `quick' denotes both `quick-no-vio2vo'
+and `quick-and-vio2vo'. Element 2 specifies the result of
+`coq-par-job-needs-compilation', nil for don't compile, t for do
+compile. Elements 3-5 specify side effects. Element 3 which file
+must be deleted, where nil means no file must be deleted. Element
+4 specifies which file name must be stored in the
+`required-obj-file' property of the job. This file will be used
+as the compiled module library. In case compilation is
+needed (element 2 equals t), this is the target of the
+compilation. Element 5 specifies the file whose time stamp must
+be stored in the `obj-mod-time' property of the job. A value of
+nil there specifies that the `obj-mod-time' property should
+contain nil. Element 5 is a bit superfluous, because it must be
+set precisely when no compilation is needed (element 2 equals
+nil) and then it must equal element 4.
+
+This list contains 1 test for all possible file configuration and
+relative ages.")
+
+;; missing test cases for some objects with identical time stamp
+;;
+;; src-vo-dep-vio
+;; 
+;; src-vo-dep vio
+;; vio src-vo-dep
+;; src-vo-vio dep
+;; dep src-vo-vio
+;; src-dep-vio vo
+;; vo src-dep-vio
+;; vo-dep-vio src
+;; src vo-dep-vio
+;; 
+;; src-vo dep-vio
+;; dep-vio src-vo
+;; src-dep vo-vio
+;; vo-vio src-dep
+;; src-vio vo-dep
+;; vo-dep src-vio
+;; 
+;; src-vo dep vio
+;; src-vo vio dep
+;; dep src-vo vio
+;; dep vio src-vo
+;; vio src-vo dep
+;; vio dep src-vo
+;; 
+;; src-dep vo vio
+;; src-dep vio vo
+;; vo src-dep vio
+;; vo vio src-dep
+;; vio src-dep vo
+;; vio vo src-dep
+;; 
+;; src-vio vo dep
+;; src-vio dep vo
+;; vo src-vio dep
+;; vo dep src-vio
+;; dep src-vio vo
+;; dep vo src-vio
+;; 
+;; vo-dep src vio
+;; vo-dep vio src
+;; src vo-dep vio
+;; src vio vo-dep
+;; vio vo-dep src
+;; vio src vo-dep
+;; 
+;; vo-vio src dep
+;; vo-vio dep src
+;; src vo-vio dep
+;; src dep vo-vio
+;; dep vo-vio src
+;; dep src vo-vio
+;; 
+;; dep-vio src vo
+;; dep-vio vo src
+;; src dep-vio vo
+;; src vo dep-vio
+;; vo dep-vio src
+;; vo src dep-vio
+
+(defun test-coq-par-test-data-invarint ()
+  "Wellformedness check for the test specifications."
+  (mapc
+   (lambda (test)
+     (let ((test-id (format "%s" (car test))))
+       ;; a test is a list of 4 elements and the first element is a list itself
+       (assert
+	(and
+	 (eq (length test) 4)
+	 (listp (car test)))
+	nil (concat test-id " 1"))
+       (mapc
+	(lambda (variant)
+	  ;; a variant is a list of 5 elements
+	  (assert (eq (length variant) 5) nil (concat test-id " 2"))
+	  (let ((compilation-result (nth 1 variant))
+		(delete-result (nth 2 variant))
+		(req-obj-result (nth 3 variant))
+		(obj-mod-result (nth 4 variant)))
+	    ;; when the obj-mod-time field is set, it must be equal to
+	    ;; the required-obj-file field
+	    (assert (or (not obj-mod-result)
+			(eq req-obj-result obj-mod-result))
+		    nil (concat test-id " 3"))
+	    (if compilation-result
+		;; when compilation is t, obj-mod-time must be set
+		(assert (not obj-mod-result) nil (concat test-id " 4"))
+	      ;; when compilation? is nil, obj-mod-result must be nil
+	      (assert obj-mod-result nil (concat test-id " 5")))
+	    ;; the delete field, when set, must be a member of the files list
+	    (assert (or (not delete-result)
+			(member delete-result (car test)))
+		    nil (concat test-id " 6"))))
+	  (cdr test))))
+   coq-par-job-needs-compilation-tests))
+
+(defun test-coq-par-sym-to-file (dir sym)
+  "Convert a test file symbol SYM to a file name in directory DIR."
+  (let ((file (cond
+	       ((eq sym 'src) "a.v")
+	       ((eq sym 'dep) "dep.vo")
+	       ((eq sym 'vo) "a.vo")
+	       ((eq sym 'vio) "a.vio")
+	       (t (assert nil)))))
+    (concat dir "/" file)))
+
+(defun test-coq-par-one-test (counter dir files variant dep-just-compiled)
+  "Do one test for one specific `coq-compile-quick' value.
+
+This function creates the files in DIR, sets up a job with the
+necessary fields, calls `coq-par-job-needs-compilation-tests' and
+test the result and side effects wth `assert'."
+  (let ((id (format "%s: %s %s%s" counter (car variant) files
+		    (if dep-just-compiled " just" "")))
+	(job (make-symbol "coq-compile-job-symbol"))
+	(module-vo-file (concat dir "/a.vo"))
+	(quick-mode (car variant))
+	(compilation-result (nth 1 variant))
+	(delete-result (nth 2 variant))
+	(req-obj-result (nth 3 variant))
+	(obj-mod-result (nth 4 variant))
+	result non-deleted-files)
+    (message "test case %s" id)
+    (ignore-errors
+      (delete-directory dir t))
+    (make-directory dir)
+    (setq coq-compile-quick quick-mode)
+    (put job 'vo-file module-vo-file)
+    (put job 'src-file (coq-library-src-of-vo-file module-vo-file))
+    (put job 'youngest-coqc-dependency '(0 0))
+    (put job 'name id)
+    ;; create files in order
+    (mapc
+     (lambda (sym)
+       (let ((file (test-coq-par-sym-to-file dir sym)))
+	 ;;(message "file create for %s: %s" sym file)
+	 (with-temp-file file t)
+	 (when (eq sym 'dep)
+	   (put job 'youngest-coqc-dependency (nth 5 (file-attributes file))))
+	 (unless (eq sym delete-result)
+	   (push file non-deleted-files))
+	 (sleep-for 0 10)
+	 ))
+     files)
+    (when dep-just-compiled
+      (put job 'youngest-coqc-dependency 'just-compiled))
+    (setq result (coq-par-job-needs-compilation job))
+    ;; check result
+    (assert (eq result compilation-result)
+	    nil (concat id " result"))
+    ;; check file deletion
+    (assert (or (not delete-result)
+		(not (file-attributes
+		      (test-coq-par-sym-to-file dir delete-result))))
+	    nil (concat id " delete file"))
+    ;; check no other file is deleted
+    (mapc
+     (lambda (f)
+       (assert (file-attributes f)
+	       nil (concat id " non del file " f)))
+     non-deleted-files)
+    ;; check value of 'required-obj-file property
+    (assert (equal (get job 'required-obj-file)
+		   (test-coq-par-sym-to-file dir req-obj-result))
+	    nil (concat id " required-obj-file"))
+    ;; check 'obj-mod-time property
+    (if obj-mod-result
+	(assert
+	 (equal
+	  (get job 'obj-mod-time)
+	  (nth 5 (file-attributes
+		  (test-coq-par-sym-to-file dir obj-mod-result))))
+	 nil (concat id " obj-mod-time non nil"))
+      (assert (not (get job 'obj-mod-time))
+	      nil (concat id " obj-mod-time nil")))
+    ;; check 'use-quick property
+    (assert (eq (not (not (and compilation-result (eq req-obj-result 'vio))))
+		(get job 'use-quick))
+	    nil (concat id " use-quick"))))
+
+(defvar test-coq-par-counter 0
+  "Stupid counter.")
+
+(defun test-coq-par-one-spec (dir files variant dep-just-compiled)
+  "Run one test for one variant and split it for the 2 quick settings."
+  (if (eq (car variant) 'quick)
+      (progn
+	(test-coq-par-one-test test-coq-par-counter dir files
+			       (cons 'quick-no-vio2vo (cdr variant))
+			       dep-just-compiled)
+	(setq test-coq-par-counter (1+ test-coq-par-counter))
+	(test-coq-par-one-test test-coq-par-counter dir files
+			       (cons 'quick-and-vio2vo (cdr variant))
+			       dep-just-compiled))
+    (test-coq-par-one-test test-coq-par-counter dir files variant
+			   dep-just-compiled))
+  (setq test-coq-par-counter (1+ test-coq-par-counter)))
+
+(defun test-coq-par-job-needs-compilation (dir)
+  "Check test date wellformedness and run all the tests."
+  (test-coq-par-test-data-invarint)
+  (setq test-coq-par-counter 1)
+  (mapc
+   (lambda (test)
+     (mapc
+      (lambda (variant)
+	(test-coq-par-one-spec dir (car test) variant nil)
+	(when (eq (car (last (car test))) 'dep)
+	  (test-coq-par-one-spec dir (car test) variant t)))
+      (cdr test)))
+   coq-par-job-needs-compilation-tests))
+
+(condition-case err
+    (progn
+      (test-coq-par-job-needs-compilation (make-temp-name "/tmp/coq-par-test"))
+      (message "test completed successfully"))
+  (error
+   (message "test failed with %s" err)
+   (kill-emacs 1)))
+
+
+(provide 'coq-par-test)
+
+;;; coq-par-test.el ends here

--- a/coq/coq-par-test.el
+++ b/coq/coq-par-test.el
@@ -752,13 +752,22 @@ relative ages.")
 	  ;; a variant is a list of 4 elements
 	  (assert (eq (length variant) 4) nil (concat test-id " 2"))
 	  (let ((files (coq-par-test-flatten-files (car test)))
+		(quick-mode (car variant))
 		(compilation-result (nth 1 variant))
 		(delete-result (nth 2 variant))
 		(req-obj-result (nth 3 variant)))
 	    ;; the delete field, when set, must be a member of the files list
 	    (assert (or (not delete-result)
 			(member delete-result files))
-		    nil (concat test-id " 3"))))
+		    nil (concat test-id " 3"))
+	    ;; 8.4 compatibility check
+	    (when (and (or (eq quick-mode 'no-quick) (eq quick-mode 'ensure-vo))
+		       (not (member 'vio files)))
+	      (assert (not delete-result)
+		      nil (concat test-id " 4"))
+	      (assert (eq compilation-result
+			  (not (eq (car (last (car test))) 'vo)))
+		      nil (concat test-id " 5")))))
 	  (cdr test))))
    coq-par-job-needs-compilation-tests))
 

--- a/coq/coq-par-test.el
+++ b/coq/coq-par-test.el
@@ -28,13 +28,13 @@
     ;; ====================================================================
     ;; all of src dep vo vio present
     ((src dep vo vio)
-     (no-quick           nil            nil       vio)
-     (quick              nil            nil       vio)
+     (no-quick           nil            nil       vo )
+     (quick              nil            nil       vo )
      (ensure-vo          nil            vio       vo ))
 
     ((src dep vio vo)
-     (no-quick           nil            nil       vo )
-     (quick              nil            nil       vo )
+     (no-quick           nil            nil       vio)
+     (quick              nil            nil       vio)
      (ensure-vo          nil            vio       vo ))
 
     ((src vo dep vio)    
@@ -59,13 +59,13 @@
 
     ;; present files   | compilation? | delete | 'req-obj-file
     ((dep src vio vo)
-     (no-quick           nil            nil       vo )
-     (quick              nil            nil       vo )
+     (no-quick           nil            nil       vio)
+     (quick              nil            nil       vio)
      (ensure-vo          nil            vio       vo ))
 
     ((dep src vo vio)
-     (no-quick           nil            nil       vio)
-     (quick              nil            nil       vio)
+     (no-quick           nil            nil       vo )
+     (quick              nil            nil       vo )
      (ensure-vo          nil            vio       vo ))
 
     ((dep vo vio src)
@@ -219,13 +219,13 @@
     ;; present files   | compilation? | delete | 'req-obj-file
     ;; only src vo vio present
     ((src vo vio)
-     (no-quick           nil            nil      vio )
-     (quick              nil            nil      vio )
+     (no-quick           nil            nil       vo )
+     (quick              nil            nil       vo )
      (ensure-vo          nil            vio       vo ))
 
     ((src vio vo)
-     (no-quick           nil            nil      vo  )
-     (quick              nil            nil      vo  )
+     (no-quick           nil            nil       vio)
+     (quick              nil            nil       vio)
      (ensure-vo          nil            vio       vo ))
 
     ((vo src vio)
@@ -357,8 +357,8 @@
 
     (((src dep) (vo vio))
      ;; could also use the vio as 'req-obj-file in the first 2 cases here
-     (no-quick           nil            nil       vo)
-     (quick              nil            nil       vo)
+     (no-quick           nil            nil       vio)
+     (quick              nil            nil       vio)
      (ensure-vo          nil            vio       vo ))
 
     (((vo vio) (src dep))
@@ -410,13 +410,13 @@
 
     ;; present files   | compilation? | delete | 'req-obj-file
     (((src dep) vo vio)
-     (no-quick           nil            nil       vio)
-     (quick              nil            nil       vio)
+     (no-quick           nil            nil       vo )
+     (quick              nil            nil       vo )
      (ensure-vo          nil            vio       vo ))
 
     (((src dep) vio vo)
-     (no-quick           nil            nil       vo )
-     (quick              nil            nil       vo )
+     (no-quick           nil            nil       vio)
+     (quick              nil            nil       vio)
      (ensure-vo          nil            vio       vo ))
 
     ((vo (src dep) vio)
@@ -518,8 +518,8 @@
 
     ((src dep (vo vio))
      ;; could also use the vio as 'req-obj-file in the first 2 cases here
-     (no-quick           nil            nil       vo)
-     (quick              nil            nil       vo)
+     (no-quick           nil            nil       vio)
+     (quick              nil            nil       vio)
      (ensure-vo          nil            vio       vo ))
 
     ((dep (vo vio) src)
@@ -529,8 +529,8 @@
 
     ((dep src (vo vio))
      ;; could also use the vio as 'req-obj-file in the first 2 cases here
-     (no-quick           nil            nil       vo)
-     (quick              nil            nil       vo)
+     (no-quick           nil            nil       vio)
+     (quick              nil            nil       vio)
      (ensure-vo          nil            vio       vo ))
 
     (((dep vio) src vo)
@@ -672,8 +672,8 @@
 
     ((src (vio vo))
      ;; could also use the vio as 'req-obj-file in the first 2 cases here
-     (no-quick           nil            nil       vo )
-     (quick              nil            nil       vo )
+     (no-quick           nil            nil       vio)
+     (quick              nil            nil       vio)
      (ensure-vo          nil            vio       vo ))
 
     ;; 2 files with identical time stamp out of 2 files

--- a/coq/coq-par-test.el
+++ b/coq/coq-par-test.el
@@ -21,7 +21,7 @@
 
 (require 'coq-par-compile)
 
-(defconst coq-par-job-needs-compilation-tests
+(defconst coq--par-job-needs-compilation-tests
   ;; for documentation see the doc string following the init value
   '(
     ;; present files   | compilation? | delete | 'req-obj-file
@@ -769,7 +769,7 @@ relative ages.")
 			  (not (eq (car (last (car test))) 'vo)))
 		      nil (concat test-id " 5")))))
 	  (cdr test))))
-   coq-par-job-needs-compilation-tests))
+   coq--par-job-needs-compilation-tests))
 
 (defun test-coq-par-sym-to-file (dir sym)
   "Convert a test file symbol SYM to a file name in directory DIR."
@@ -785,7 +785,7 @@ relative ages.")
   "Do one test for one specific `coq-compile-quick' value.
 
 This function creates the files in DIR, sets up a job with the
-necessary fields, calls `coq-par-job-needs-compilation-tests' and
+necessary fields, calls `coq--par-job-needs-compilation-tests' and
 test the result and side effects wth `assert'."
   (let ((id (format "%s: %s %s%s" counter (car variant) file-descr
 		    (if dep-just-compiled " just" "")))
@@ -937,7 +937,7 @@ test the result and side effects wth `assert'."
 	(when (eq (car (last (car test))) 'dep)
 	  (test-coq-par-one-spec dir (car test) variant t)))
       (cdr test)))
-   coq-par-job-needs-compilation-tests))
+   coq--par-job-needs-compilation-tests))
 
 (condition-case err
     (progn

--- a/coq/coq-par-test.el
+++ b/coq/coq-par-test.el
@@ -17,7 +17,6 @@
 ;;; TODO:
 ;;
 ;; - integrate into PG build and test(?) system
-;; - add tests for files with identical time stamps
 
 
 (require 'coq-par-compile)
@@ -25,273 +24,673 @@
 (defconst coq-par-job-needs-compilation-tests
   ;; for documentation see the doc string following the init value
   '(
-    ;; present files   | compilation? | delete | 'req-obj-file | 'obj-mod-t
+    ;; present files   | compilation? | delete | 'req-obj-file
     ;; ====================================================================
     ;; all of src dep vo vio present
     ((src dep vo vio)
-     (no-quick           nil            nil       vio            vio)
-     (quick              nil            nil       vio            vio)
-     (ensure-vo          nil            vio       vo             vo))
+     (no-quick           nil            nil       vio)
+     (quick              nil            nil       vio)
+     (ensure-vo          nil            vio       vo ))
 
     ((src dep vio vo)
-     (no-quick           nil            nil       vo             vo  )
-     (quick              nil            nil       vo             vo  )
-     (ensure-vo          nil            vio       vo             vo  ))
+     (no-quick           nil            nil       vo )
+     (quick              nil            nil       vo )
+     (ensure-vo          nil            vio       vo ))
 
     ((src vo dep vio)    
-     (no-quick           nil            vo        vio            vio )
-     (quick              nil            vo        vio            vio )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           nil            vo        vio)
+     (quick              nil            vo        vio)
+     (ensure-vo          t              vio       vo ))
 
     ((src vo vio dep)
-     (no-quick           t              vio       vo             nil )
-     (quick              t              vo        vio            nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
 
     ((src vio dep vo)
-     (no-quick           nil            vio       vo             vo  )
-     (quick              nil            vio       vo             vo  )
-     (ensure-vo          nil            vio       vo             vo  ))
+     (no-quick           nil            vio       vo )
+     (quick              nil            vio       vo )
+     (ensure-vo          nil            vio       vo ))
 
     ((src vio vo dep)
-     (no-quick           t              vio       vo             nil )
-     (quick              t              vo        vio            nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
 
-    ;; present files   | compilation? | delete | 'req-obj-file | 'obj-mod-t
+    ;; present files   | compilation? | delete | 'req-obj-file
     ((dep src vio vo)
-     (no-quick           nil            nil       vo             vo  )
-     (quick              nil            nil       vo             vo  )
-     (ensure-vo          nil            vio       vo             vo  ))
+     (no-quick           nil            nil       vo )
+     (quick              nil            nil       vo )
+     (ensure-vo          nil            vio       vo ))
 
     ((dep src vo vio)
-     (no-quick           nil            nil       vio            vio )
-     (quick              nil            nil       vio            vio )
-     (ensure-vo          nil            vio       vo             vo  ))
+     (no-quick           nil            nil       vio)
+     (quick              nil            nil       vio)
+     (ensure-vo          nil            vio       vo ))
 
     ((dep vo vio src)
-     (no-quick           t              vio       vo             nil )
-     (quick              t              vo        vio            nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
 
     ((dep vo src vio)
-     (no-quick           nil            vo        vio            vio )
-     (quick              nil            vo        vio            vio )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           nil            vo        vio)
+     (quick              nil            vo        vio)
+     (ensure-vo          t              vio       vo ))
 
     ((dep vio vo src)
-     (no-quick           t              vio       vo             nil )
-     (quick              t              vo        vio            nil )
-     (ensure-vo          t              vio       vo             nil  ))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
 
     ((dep vio src vo)
-     (no-quick           nil            vio       vo             vo  )
-     (quick              nil            vio       vo             vo  )
-     (ensure-vo          nil            vio       vo             vo  ))
+     (no-quick           nil            vio       vo )
+     (quick              nil            vio       vo )
+     (ensure-vo          nil            vio       vo ))
 
     ((vo src dep vio)
-     (no-quick           nil            vo        vio            vio )
-     (quick              nil            vo        vio            vio )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           nil            vo        vio)
+     (quick              nil            vo        vio)
+     (ensure-vo          t              vio       vo ))
 
-    ;; present files   | compilation? | delete | 'req-obj-file | 'obj-mod-t
+    ;; present files   | compilation? | delete | 'req-obj-file
     ((vo src vio dep)
-     (no-quick           t              vio       vo             nil )
-     (quick              t              vo        vio            nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
 
     ((vo dep src vio)
-     (no-quick           nil            vo       vio             vio )
-     (quick              nil            vo       vio             vio )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           nil            vo       vio )
+     (quick              nil            vo       vio )
+     (ensure-vo          t              vio       vo ))
 
     ((vo dep vio src)
-     (no-quick           t              vio       vo             nil )
-     (quick              t              vo        vio            nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
 
     ((vo vio src dep)
-     (no-quick           t              vio      vo              nil )
-     (quick              t              vo       vio             nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t              vio      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              vio       vo ))
 
     ((vo vio dep src)
-     (no-quick           t              vio      vo              nil )
-     (quick              t              vo       vio             nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t              vio      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              vio       vo ))
 
     ((vio src vo dep)
-     (no-quick           t              vio      vo              nil )
-     (quick              t              vo       vio             nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t              vio      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              vio       vo ))
 
     ((vio src dep vo)
-     (no-quick           nil            vio      vo              vo  )
-     (quick              nil            vio      vo              vo  )
-     (ensure-vo          nil            vio       vo             vo  ))
+     (no-quick           nil            vio      vo  )
+     (quick              nil            vio      vo  )
+     (ensure-vo          nil            vio       vo ))
 
     ((vio dep vo src)
-     (no-quick           t              vio      vo              nil )
-     (quick              t              vo       vio             nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t              vio      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              vio       vo ))
 
-    ;; present files   | compilation? | delete | 'req-obj-file | 'obj-mod-t
+    ;; present files   | compilation? | delete | 'req-obj-file
     ((vio dep src vo)
-     (no-quick           nil            vio      vo              vo  )
-     (quick              nil            vio      vo              vo  )
-     (ensure-vo          nil            vio       vo             vo  ))
+     (no-quick           nil            vio      vo  )
+     (quick              nil            vio      vo  )
+     (ensure-vo          nil            vio       vo ))
 
     ((vio vo dep src)
-     (no-quick           t              vio      vo              nil )
-     (quick              t              vo       vio             nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t              vio      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              vio       vo ))
 
     ((vio vo src dep)
-     (no-quick           t              vio      vo              nil )
-     (quick              t              vo       vio             nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t              vio      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              vio       vo ))
 
 
     ;; only src dep vo present
     ((src dep vo)
-     (no-quick           nil            nil      vo              vo  )
-     (quick              nil            nil      vo              vo  )
-     (ensure-vo          nil            nil      vo              vo  ))
+     (no-quick           nil            nil      vo  )
+     (quick              nil            nil      vo  )
+     (ensure-vo          nil            nil      vo  ))
 
     ((src vo dep)
-     (no-quick           t              nil      vo              nil )
-     (quick              t              vo       vio             nil )
-     (ensure-vo          t              nil      vo              nil ))
+     (no-quick           t              nil      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              nil      vo  ))
 
     ((dep src vo)
-     (no-quick           nil            nil      vo              vo  )
-     (quick              nil            nil      vo              vo  )
-     (ensure-vo          nil            nil      vo              vo  ))
+     (no-quick           nil            nil      vo  )
+     (quick              nil            nil      vo  )
+     (ensure-vo          nil            nil      vo  ))
 
     ((dep vo src)
-     (no-quick           t              nil      vo              nil )
-     (quick              t              vo       vio             nil )
-     (ensure-vo          t              nil      vo              nil ))
+     (no-quick           t              nil      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              nil      vo  ))
 
     ((vo src dep)
-     (no-quick           t              nil      vo              nil )
-     (quick              t              vo       vio             nil )
-     (ensure-vo          t              nil      vo              nil ))
+     (no-quick           t              nil      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              nil      vo  ))
 
     ((vo dep src)
-     (no-quick           t              nil      vo              nil )
-     (quick              t              vo       vio             nil )
-     (ensure-vo          t              nil      vo              nil ))
+     (no-quick           t              nil      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              nil      vo  ))
 
 
-    ;; present files   | compilation? | delete | 'req-obj-file | 'obj-mod-t
+    ;; present files   | compilation? | delete | 'req-obj-file
     ;; only src dep vio present
     ((src dep vio)
-     (no-quick           nil            nil      vio             vio )
-     (quick              nil            nil      vio             vio )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           nil            nil      vio )
+     (quick              nil            nil      vio )
+     (ensure-vo          t              vio       vo ))
 
     ((src vio dep)
-     (no-quick           t             vio       vo              nil )
-     (quick              t             nil       vio             nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t             vio       vo  )
+     (quick              t             nil       vio )
+     (ensure-vo          t              vio       vo ))
 
     ((dep src vio)
-     (no-quick           nil           nil       vio             vio )
-     (quick              nil           nil       vio             vio )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           nil           nil       vio )
+     (quick              nil           nil       vio )
+     (ensure-vo          t              vio       vo ))
 
     ((dep vio src)
-     (no-quick           t             vio       vo              nil )
-     (quick              t             nil       vio             nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t             vio       vo  )
+     (quick              t             nil       vio )
+     (ensure-vo          t              vio       vo ))
 
     ((vio src dep)
-     (no-quick           t             vio       vo              nil )
-     (quick              t             nil       vio             nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t             vio       vo  )
+     (quick              t             nil       vio )
+     (ensure-vo          t              vio       vo ))
 
     ((vio dep src)
-     (no-quick           t             vio       vo              nil )
-     (quick              t             nil       vio             nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t             vio       vo  )
+     (quick              t             nil       vio )
+     (ensure-vo          t              vio       vo ))
 
 
-    ;; present files   | compilation? | delete | 'req-obj-file | 'obj-mod-t
+    ;; present files   | compilation? | delete | 'req-obj-file
     ;; only src vo vio present
     ((src vo vio)
-     (no-quick           nil            nil      vio             vio )
-     (quick              nil            nil      vio             vio )
-     (ensure-vo          nil            vio       vo             vo  ))
+     (no-quick           nil            nil      vio )
+     (quick              nil            nil      vio )
+     (ensure-vo          nil            vio       vo ))
 
     ((src vio vo)
-     (no-quick           nil            nil      vo              vo  )
-     (quick              nil            nil      vo              vo  )
-     (ensure-vo          nil            vio       vo             vo  ))
+     (no-quick           nil            nil      vo  )
+     (quick              nil            nil      vo  )
+     (ensure-vo          nil            vio       vo ))
 
     ((vo src vio)
-     (no-quick           nil            vo       vio             vio )
-     (quick              nil            vo       vio             vio )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           nil            vo       vio )
+     (quick              nil            vo       vio )
+     (ensure-vo          t              vio       vo ))
 
     ((vo vio src)
-     (no-quick           t              vio      vo              nil )
-     (quick              t              vo       vio             nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t              vio      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              vio       vo ))
 
     ((vio src vo)
-     (no-quick           nil            vio      vo              vo  )
-     (quick              nil            vio      vo              vo  )
-     (ensure-vo          nil            vio      vo              vo  ))
+     (no-quick           nil            vio      vo  )
+     (quick              nil            vio      vo  )
+     (ensure-vo          nil            vio      vo  ))
 
     ((vio vo src)
-     (no-quick           t              vio      vo              nil )
-     (quick              t              vo       vio             nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t              vio      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              vio       vo ))
 
 
-    ;; present files   | compilation? | delete | 'req-obj-file | 'obj-mod-t
+    ;; present files   | compilation? | delete | 'req-obj-file
     ;; only src dep present
     ((src dep)
-     (no-quick           t              nil      vo              nil )
-     (quick              t              nil      vio             nil )
-     (ensure-vo          t              nil      vo              nil ))
+     (no-quick           t              nil      vo  )
+     (quick              t              nil      vio )
+     (ensure-vo          t              nil      vo  ))
 
     ((dep src)
-     (no-quick           t              nil      vo              nil )
-     (quick              t              nil      vio             nil )
-     (ensure-vo          t              nil      vo              nil ))
+     (no-quick           t              nil      vo  )
+     (quick              t              nil      vio )
+     (ensure-vo          t              nil      vo  ))
 
 
     ;; only src vo present
     ((src vo)
-     (no-quick           nil            nil      vo              vo  )
-     (quick              nil            nil      vo              vo  )
-     (ensure-vo          nil            nil      vo              vo  ))
+     (no-quick           nil            nil      vo  )
+     (quick              nil            nil      vo  )
+     (ensure-vo          nil            nil      vo  ))
 
     ((vo src)
-     (no-quick           t              nil      vo              nil )
-     (quick              t              vo       vio             nil )
-     (ensure-vo          t              nil      vo              nil ))
+     (no-quick           t              nil      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              nil      vo  ))
 
 
     ;; only src vio present
     ((src vio)
-     (no-quick           nil            nil      vio             vio )
-     (quick              nil            nil      vio             vio )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           nil            nil      vio )
+     (quick              nil            nil      vio )
+     (ensure-vo          t              vio       vo ))
 
     ((vio src)
-     (no-quick           t              vio      vo              nil )
-     (quick              t              nil      vio             nil )
-     (ensure-vo          t              vio       vo             nil ))
+     (no-quick           t              vio      vo  )
+     (quick              t              nil      vio )
+     (ensure-vo          t              vio       vo ))
 
 
     ;; only src present
     ((src)
-     (no-quick           t              nil      vo              nil )
-     (quick              t              nil      vio             nil )
-     (ensure-vo          t              nil      vo              nil ))
+     (no-quick           t              nil      vo  )
+     (quick              t              nil      vio )
+     (ensure-vo          t              nil      vo  ))
+
+    ;; present files   | compilation? | delete | 'req-obj-file
+    ;;
+    ;; test cases for some objects with identical time stamp
+    ;;
+    ;; 4 files with same time stamp
+    (((src vo dep vio))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ;; 3 files with same time stamp
+    (((src vo dep) vio)
+     (no-quick           nil            vo       vio )
+     (quick              nil            vo       vio )
+     (ensure-vo          t              vio       vo ))
+
+    ((vio (src vo dep))
+     (no-quick           t              vio      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              vio       vo ))
+
+    (((src vo vio) dep)
+     (no-quick           t              vio      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              vio       vo ))
+
+    ((dep (src vo vio))
+     (no-quick           t              vio      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              vio       vo ))
+
+    (((src dep vio) vo)
+     (no-quick           nil            vio      vo  )
+     (quick              nil            vio      vo  )
+     (ensure-vo          nil            vio       vo ))
+
+    ;; present files   | compilation? | delete | 'req-obj-file
+    ((vo (src dep vio))
+     (no-quick           t              vio      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              vio       vo ))
+
+    (((vo dep vio) src)
+     (no-quick           t              vio      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              vio       vo ))
+
+    ((src (vo dep vio))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ;; 2 times 2 files with same time stamp
+    (((src vo) (dep vio))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    (((dep vio) (src vo))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    (((src dep) (vo vio))
+     ;; could also use the vio as 'req-obj-file in the first 2 cases here
+     (no-quick           nil            nil       vo)
+     (quick              nil            nil       vo)
+     (ensure-vo          nil            vio       vo ))
+
+    (((vo vio) (src dep))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    (((src vio) (vo dep))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ;; present files   | compilation? | delete | 'req-obj-file
+    (((vo dep) (src vio))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ;; 2 files with same time stamp
+    (((src vo) dep vio)
+     (no-quick           nil            vo        vio)
+     (quick              nil            vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    (((src vo) vio dep)
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((dep (src vo) vio)
+     (no-quick           nil            vo        vio)
+     (quick              nil            vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((dep vio (src vo))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((vio (src vo) dep)
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((vio dep (src vo))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ;; present files   | compilation? | delete | 'req-obj-file
+    (((src dep) vo vio)
+     (no-quick           nil            nil       vio)
+     (quick              nil            nil       vio)
+     (ensure-vo          nil            vio       vo ))
+
+    (((src dep) vio vo)
+     (no-quick           nil            nil       vo )
+     (quick              nil            nil       vo )
+     (ensure-vo          nil            vio       vo ))
+
+    ((vo (src dep) vio)
+     (no-quick           nil            vo        vio)
+     (quick              nil            vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((vo vio (src dep))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((vio (src dep) vo)
+     (no-quick           nil            vio      vo  )
+     (quick              nil            vio      vo  )
+     (ensure-vo          nil            vio       vo ))
+
+    ((vio vo (src dep))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    (((src vio) vo dep)
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    (((src vio) dep vo)
+     (no-quick           nil            vio      vo  )
+     (quick              nil            vio      vo  )
+     (ensure-vo          nil            vio      vo  ))
+
+    ((vo (src vio) dep)
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ;; present files   | compilation? | delete | 'req-obj-file
+    ((vo dep (src vio))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((dep (src vio) vo)
+     (no-quick           nil            vio      vo  )
+     (quick              nil            vio      vo  )
+     (ensure-vo          nil            vio       vo ))
+
+    ((dep vo (src vio))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    (((vo dep) src vio)
+     (no-quick           nil            vo       vio )
+     (quick              nil            vo       vio )
+     (ensure-vo          t              vio       vo ))
+
+    (((vo dep) vio src)
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((src (vo dep) vio)
+     (no-quick           nil            vo        vio)
+     (quick              nil            vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((src vio (vo dep))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((vio (vo dep) src)
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((vio src (vo dep))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ;; present files   | compilation? | delete | 'req-obj-file
+    (((vo vio) src dep)
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    (((vo vio) dep src)
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((src (vo vio) dep)
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((src dep (vo vio))
+     ;; could also use the vio as 'req-obj-file in the first 2 cases here
+     (no-quick           nil            nil       vo)
+     (quick              nil            nil       vo)
+     (ensure-vo          nil            vio       vo ))
+
+    ((dep (vo vio) src)
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((dep src (vo vio))
+     ;; could also use the vio as 'req-obj-file in the first 2 cases here
+     (no-quick           nil            nil       vo)
+     (quick              nil            nil       vo)
+     (ensure-vo          nil            vio       vo ))
+
+    (((dep vio) src vo)
+     (no-quick           nil            vio      vo  )
+     (quick              nil            vio      vo  )
+     (ensure-vo          nil            vio       vo ))
+
+    (((dep vio) vo src)
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((src (dep vio) vo)
+     (no-quick           nil            vio      vo  )
+     (quick              nil            vio      vo  )
+     (ensure-vo          nil            vio       vo ))
+
+    ;; present files   | compilation? | delete | 'req-obj-file
+    ((src vo (dep vio))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((vo (dep vio) src)
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((vo src (dep vio))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ;; 2 files with the same time stamp out of 3 files
+    ;; without vio
+    (((src dep vo))
+     (no-quick           t              nil       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              nil       vo ))
+
+    (((src dep) vo)
+     (no-quick           nil            nil      vo  )
+     (quick              nil            nil      vo  )
+     (ensure-vo          nil            nil      vo  ))
+
+    ((vo (src dep))
+     (no-quick           t              nil       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              nil       vo ))
+
+    (((src vo) dep)
+     (no-quick           t              nil       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              nil       vo ))
+
+    ((dep (src vo))
+     (no-quick           t              nil       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              nil       vo ))
+
+    (((dep vo) src)
+     (no-quick           t              nil       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              nil       vo ))
+
+    ;; present files   | compilation? | delete | 'req-obj-file
+    ((src (dep vo))
+     (no-quick           t              nil       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              nil       vo ))
+
+    ;; without vo
+    (((src dep vio))
+     (no-quick           t              vio       vo )
+     (quick              t              nil       vio)
+     (ensure-vo          t              vio       vo ))
+
+    (((src dep) vio)
+     (no-quick           nil           nil       vio )
+     (quick              nil           nil       vio )
+     (ensure-vo          t              vio       vo ))
+
+    ((vio (src dep))
+     (no-quick           t              vio       vo )
+     (quick              t              nil       vio)
+     (ensure-vo          t              vio       vo ))
+
+    (((src vio) dep)
+     (no-quick           t              vio       vo )
+     (quick              t              nil       vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((dep (src vio))
+     (no-quick           t              vio       vo )
+     (quick              t              nil       vio)
+     (ensure-vo          t              vio       vo ))
+
+    (((dep vio) src)
+     (no-quick           t              vio       vo )
+     (quick              t              nil       vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((src (dep vio))
+     (no-quick           t              vio       vo )
+     (quick              t              nil       vio)
+     (ensure-vo          t              vio       vo ))
+
+    ;; without dep
+    (((src vio vo))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    (((src vio) vo)
+     (no-quick           nil            vio      vo  )
+     (quick              nil            vio      vo  )
+     (ensure-vo          nil            vio      vo  ))
+
+    ((vo (src vio))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    (((src vo) vio)
+     (no-quick           nil            vo       vio )
+     (quick              nil            vo       vio )
+     (ensure-vo          t              vio       vo ))
+
+    ;; present files   | compilation? | delete | 'req-obj-file
+    ((vio (src vo))
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    (((vio vo) src)
+     (no-quick           t              vio       vo )
+     (quick              t              vo        vio)
+     (ensure-vo          t              vio       vo ))
+
+    ((src (vio vo))
+     ;; could also use the vio as 'req-obj-file in the first 2 cases here
+     (no-quick           nil            nil       vo )
+     (quick              nil            nil       vo )
+     (ensure-vo          nil            vio       vo ))
+
+    ;; 2 files with identical time stamp out of 2 files
+    (((src dep))
+     (no-quick           t              nil      vo  )
+     (quick              t              nil      vio )
+     (ensure-vo          t              nil      vo  ))
+
+    (((src vo))
+     (no-quick           t              nil      vo  )
+     (quick              t              vo       vio )
+     (ensure-vo          t              nil      vo  ))
+
+    (((src vio))
+     (no-quick           t              vio      vo  )
+     (quick              t              nil      vio )
+     (ensure-vo          t              vio      vo  ))
     )
   "Test and result specification for `coq-par-job-needs-compilation'.
 
@@ -302,7 +701,11 @@ a (already compiled) dependency (dep.vo or dep.vio), `vo' for the
 .vo file (x.vo) and `vio' for the .vio file (x.vio). A label in
 the list denotes an existing file, a missing label a missing
 file. The first element is the oldest file, the last element the
-newest file.
+newest file. A sublist specifies a set of files with identical
+time stamps. For example, ``(src (vo vio) dep)'' specifies source
+is older than .vo and .vio, .vo and .vio have identical last
+modification time stamps and .vo and .vio are older than the
+dependency.
 
 Elements 2-4 of a test specify the results and side effects of
 `coq-par-job-needs-compilation' for all setting of
@@ -310,7 +713,7 @@ Elements 2-4 of a test specify the results and side effects of
 element 1. The options `quick-no-vio2vo' and `quick-and-vio2vo'
 are specified together with label `quick'. Each result and side
 effect specification (also called a variant in the source code
-below) is itself a list of 5 elements. Element 1 is the value for
+below) is itself a list of 4 elements. Element 1 is the value for
 `coq-compile-quick', where `quick' denotes both `quick-no-vio2vo'
 and `quick-and-vio2vo'. Element 2 specifies the result of
 `coq-par-job-needs-compilation', nil for don't compile, t for do
@@ -320,77 +723,18 @@ must be deleted, where nil means no file must be deleted. Element
 `required-obj-file' property of the job. This file will be used
 as the compiled module library. In case compilation is
 needed (element 2 equals t), this is the target of the
-compilation. Element 5 specifies the file whose time stamp must
-be stored in the `obj-mod-time' property of the job. A value of
-nil there specifies that the `obj-mod-time' property should
-contain nil. Element 5 is a bit superfluous, because it must be
-set precisely when no compilation is needed (element 2 equals
-nil) and then it must equal element 4.
+compilation.
 
 This list contains 1 test for all possible file configuration and
 relative ages.")
 
-;; missing test cases for some objects with identical time stamp
-;;
-;; src-vo-dep-vio
-;; 
-;; src-vo-dep vio
-;; vio src-vo-dep
-;; src-vo-vio dep
-;; dep src-vo-vio
-;; src-dep-vio vo
-;; vo src-dep-vio
-;; vo-dep-vio src
-;; src vo-dep-vio
-;; 
-;; src-vo dep-vio
-;; dep-vio src-vo
-;; src-dep vo-vio
-;; vo-vio src-dep
-;; src-vio vo-dep
-;; vo-dep src-vio
-;; 
-;; src-vo dep vio
-;; src-vo vio dep
-;; dep src-vo vio
-;; dep vio src-vo
-;; vio src-vo dep
-;; vio dep src-vo
-;; 
-;; src-dep vo vio
-;; src-dep vio vo
-;; vo src-dep vio
-;; vo vio src-dep
-;; vio src-dep vo
-;; vio vo src-dep
-;; 
-;; src-vio vo dep
-;; src-vio dep vo
-;; vo src-vio dep
-;; vo dep src-vio
-;; dep src-vio vo
-;; dep vo src-vio
-;; 
-;; vo-dep src vio
-;; vo-dep vio src
-;; src vo-dep vio
-;; src vio vo-dep
-;; vio vo-dep src
-;; vio src vo-dep
-;; 
-;; vo-vio src dep
-;; vo-vio dep src
-;; src vo-vio dep
-;; src dep vo-vio
-;; dep vo-vio src
-;; dep src vo-vio
-;; 
-;; dep-vio src vo
-;; dep-vio vo src
-;; src dep-vio vo
-;; src vo dep-vio
-;; vo dep-vio src
-;; vo src dep-vio
+(defun coq-par-test-flatten-files (file-descr)
+  "Flatten a file description test case list into a list of files."
+  (let (result)
+    (dolist (f file-descr result)
+      (if (listp f)
+	  (setq result (append f result))
+	(push f result)))))
 
 (defun test-coq-par-test-data-invarint ()
   "Wellformedness check for the test specifications."
@@ -405,26 +749,16 @@ relative ages.")
 	nil (concat test-id " 1"))
        (mapc
 	(lambda (variant)
-	  ;; a variant is a list of 5 elements
-	  (assert (eq (length variant) 5) nil (concat test-id " 2"))
-	  (let ((compilation-result (nth 1 variant))
+	  ;; a variant is a list of 4 elements
+	  (assert (eq (length variant) 4) nil (concat test-id " 2"))
+	  (let ((files (coq-par-test-flatten-files (car test)))
+		(compilation-result (nth 1 variant))
 		(delete-result (nth 2 variant))
-		(req-obj-result (nth 3 variant))
-		(obj-mod-result (nth 4 variant)))
-	    ;; when the obj-mod-time field is set, it must be equal to
-	    ;; the required-obj-file field
-	    (assert (or (not obj-mod-result)
-			(eq req-obj-result obj-mod-result))
-		    nil (concat test-id " 3"))
-	    (if compilation-result
-		;; when compilation is t, obj-mod-time must be set
-		(assert (not obj-mod-result) nil (concat test-id " 4"))
-	      ;; when compilation? is nil, obj-mod-result must be nil
-	      (assert obj-mod-result nil (concat test-id " 5")))
+		(req-obj-result (nth 3 variant)))
 	    ;; the delete field, when set, must be a member of the files list
 	    (assert (or (not delete-result)
-			(member delete-result (car test)))
-		    nil (concat test-id " 6"))))
+			(member delete-result files))
+		    nil (concat test-id " 3"))))
 	  (cdr test))))
    coq-par-job-needs-compilation-tests))
 
@@ -438,13 +772,13 @@ relative ages.")
 	       (t (assert nil)))))
     (concat dir "/" file)))
 
-(defun test-coq-par-one-test (counter dir files variant dep-just-compiled)
+(defun test-coq-par-one-test (counter dir file-descr variant dep-just-compiled)
   "Do one test for one specific `coq-compile-quick' value.
 
 This function creates the files in DIR, sets up a job with the
 necessary fields, calls `coq-par-job-needs-compilation-tests' and
 test the result and side effects wth `assert'."
-  (let ((id (format "%s: %s %s%s" counter (car variant) files
+  (let ((id (format "%s: %s %s%s" counter (car variant) file-descr
 		    (if dep-just-compiled " just" "")))
 	(job (make-symbol "coq-compile-job-symbol"))
 	(module-vo-file (concat dir "/a.vo"))
@@ -452,9 +786,17 @@ test the result and side effects wth `assert'."
 	(compilation-result (nth 1 variant))
 	(delete-result (nth 2 variant))
 	(req-obj-result (nth 3 variant))
-	(obj-mod-result (nth 4 variant))
-	result non-deleted-files)
-    (message "test case %s" id)
+	(different-counter 5)
+	(same-counter 5)
+	(different-not-ok t)
+	(same-not-ok t)
+	(last-different-time-stamp '(0 0))
+	same-time-stamp file-list
+	obj-mod-result result)
+    (message "test case %s/576: %s %s%s" counter (car variant) file-descr
+	     (if dep-just-compiled " just" ""))
+    (when (not compilation-result)
+      (setq obj-mod-result req-obj-result))
     (ignore-errors
       (delete-directory dir t))
     (make-directory dir)
@@ -464,18 +806,50 @@ test the result and side effects wth `assert'."
     (put job 'youngest-coqc-dependency '(0 0))
     (put job 'name id)
     ;; create files in order
-    (mapc
-     (lambda (sym)
-       (let ((file (test-coq-par-sym-to-file dir sym)))
-	 ;;(message "file create for %s: %s" sym file)
-	 (with-temp-file file t)
-	 (when (eq sym 'dep)
-	   (put job 'youngest-coqc-dependency (nth 5 (file-attributes file))))
-	 (unless (eq sym delete-result)
-	   (push file non-deleted-files))
-	 (sleep-for 0 10)
-	 ))
-     files)
+    (while different-not-ok
+      ;; (message "enter different loop %s at %s"
+      ;; 	       different-counter (current-time))
+      (setq different-not-ok nil)
+      (setq different-counter (1- different-counter))
+      (assert (> different-counter 0)
+	      nil "create files with different time stamps failed")
+      (dolist (same-descr file-descr)
+	(when (symbolp same-descr)
+	  (setq same-descr (list same-descr)))
+	(setq file-list
+	      (mapcar (lambda (sym) (test-coq-par-sym-to-file dir sym))
+		      same-descr))
+	;; (message "try %s files %s" same-descr file-list)
+	(setq same-counter 5)
+	(setq same-not-ok t)
+	(while same-not-ok
+	  (setq same-counter (1- same-counter))
+	  (assert (> same-counter 0)
+		  nil "create files with same time stamp filed")
+	  (dolist (file file-list)
+	    (with-temp-file file t))
+	  ;; check now that all the files in file-list have the same time stamp
+	  (setq same-not-ok nil)
+	  (setq same-time-stamp (nth 5 (file-attributes (car file-list))))
+	  ;; (message "got first time stamp %s" same-time-stamp)
+	  (dolist (file (cdr file-list))
+	    (let ((ots (nth 5 (file-attributes file))))
+	      ;; (message "got other time stamp %s" ots)
+	      (unless (equal same-time-stamp ots)
+		(setq same-not-ok t)))))
+	;; (message "successful finished %s" same-descr)
+	(when (member 'dep same-descr)
+	  (put job 'youngest-coqc-dependency
+	       (nth 5 (file-attributes (test-coq-par-sym-to-file dir 'dep)))))
+	;; (message "XX %s < %s = %s"
+	;; 	 last-different-time-stamp same-time-stamp
+	;; 	 (time-less-p last-different-time-stamp same-time-stamp))
+	(unless (time-less-p last-different-time-stamp same-time-stamp)
+	  ;; error - got the same time stamp
+	  ;; (message "unsuccsessful - need different retry")
+	  (setq different-not-ok t))
+	(setq last-different-time-stamp same-time-stamp)
+	(sleep-for 0 15)))
     (when dep-just-compiled
       (put job 'youngest-coqc-dependency 'just-compiled))
     (setq result (coq-par-job-needs-compilation job))
@@ -488,11 +862,12 @@ test the result and side effects wth `assert'."
 		      (test-coq-par-sym-to-file dir delete-result))))
 	    nil (concat id " delete file"))
     ;; check no other file is deleted
-    (mapc
-     (lambda (f)
-       (assert (file-attributes f)
-	       nil (concat id " non del file " f)))
-     non-deleted-files)
+    (dolist (f (coq-par-test-flatten-files file-descr))
+      (unless (eq f delete-result)
+	(assert (file-attributes (test-coq-par-sym-to-file dir f))
+		nil (format "%s non del file %s: %s"
+			    id f
+			    (test-coq-par-sym-to-file dir f)))))
     ;; check value of 'required-obj-file property
     (assert (equal (get job 'required-obj-file)
 		   (test-coq-par-sym-to-file dir req-obj-result))
@@ -510,7 +885,9 @@ test the result and side effects wth `assert'."
     ;; check 'use-quick property
     (assert (eq (not (not (and compilation-result (eq req-obj-result 'vio))))
 		(get job 'use-quick))
-	    nil (concat id " use-quick"))))
+	    nil (concat id " use-quick"))
+    (ignore-errors
+      (delete-directory dir t))))
 
 (defvar test-coq-par-counter 0
   "Stupid counter.")
@@ -531,7 +908,7 @@ test the result and side effects wth `assert'."
   (setq test-coq-par-counter (1+ test-coq-par-counter)))
 
 (defun test-coq-par-job-needs-compilation (dir)
-  "Check test date wellformedness and run all the tests."
+  "Check test data wellformedness and run all the tests."
   (test-coq-par-test-data-invarint)
   (setq test-coq-par-counter 1)
   (mapc

--- a/coq/coq-par-test.el
+++ b/coq/coq-par-test.el
@@ -791,6 +791,7 @@ test the result and side effects wth `assert'."
 	(different-not-ok t)
 	(same-not-ok t)
 	(last-different-time-stamp '(0 0))
+	(file-descr-flattened (coq-par-test-flatten-files file-descr))
 	same-time-stamp file-list
 	obj-mod-result result)
     (message "test case %s/576: %s %s%s" counter (car variant) file-descr
@@ -862,7 +863,7 @@ test the result and side effects wth `assert'."
 		      (test-coq-par-sym-to-file dir delete-result))))
 	    nil (concat id " delete file"))
     ;; check no other file is deleted
-    (dolist (f (coq-par-test-flatten-files file-descr))
+    (dolist (f file-descr-flattened)
       (unless (eq f delete-result)
 	(assert (file-attributes (test-coq-par-sym-to-file dir f))
 		nil (format "%s non del file %s: %s"
@@ -886,6 +887,14 @@ test the result and side effects wth `assert'."
     (assert (eq (not (not (and compilation-result (eq req-obj-result 'vio))))
 		(get job 'use-quick))
 	    nil (concat id " use-quick"))
+    ;; check vio2vo-needed property
+    (assert (eq
+	     (and (eq quick-mode 'quick-and-vio2vo)
+		  (eq req-obj-result 'vio)
+		  (or (eq delete-result 'vo)
+		      (not (member 'vo file-descr-flattened))))
+	     (get job 'vio2vo-needed))
+	    nil (concat id " vio2vo-needed wrong"))
     (ignore-errors
       (delete-directory dir t))))
 

--- a/coq/coq-seq-compile.el
+++ b/coq/coq-seq-compile.el
@@ -64,7 +64,7 @@ error occurred and the returned list is the (possibly empty) list
 of file names LIB-SRC-FILE depends on.
 
 If an error occurs this funtion displays
-`coq-compile-response-buffer' with the complete command and its
+`coq--compile-response-buffer' with the complete command and its
 output. The optional argument COMMAND-INTRO is only used in the
 error case. It is prepended to the displayed command.
 
@@ -77,7 +77,7 @@ break."
          (nconc (coq-include-options coq-load-path (file-name-directory lib-src-file) (coq--pre-v85))
 		(list lib-src-file)))
         coqdep-status coqdep-output)
-    (if coq-debug-auto-compilation
+    (if coq--debug-auto-compilation
         (message "call coqdep arg list: %S" coqdep-arguments))
     (with-temp-buffer
       (setq coqdep-status
@@ -85,7 +85,7 @@ break."
                    coq-dependency-analyzer nil (current-buffer) nil
                    coqdep-arguments))
       (setq coqdep-output (buffer-string)))
-    (if coq-debug-auto-compilation
+    (if coq--debug-auto-compilation
         (message "coqdep status %s, output on %s: %s"
                  coqdep-status lib-src-file coqdep-output))
     (if (or
@@ -99,7 +99,7 @@ break."
           (coq-init-compile-response-buffer
            (mapconcat 'identity full-command " "))
           (let ((inhibit-read-only t))
-            (with-current-buffer coq-compile-response-buffer
+            (with-current-buffer coq--compile-response-buffer
               (insert coqdep-output)))
           (coq-display-compile-response-buffer)
           "unsatisfied dependencies")
@@ -109,7 +109,7 @@ break."
 
 (defun coq-seq-compile-library (src-file)
   "Recompile coq library SRC-FILE.
-Display errors in buffer `coq-compile-response-buffer'."
+Display errors in buffer `coq--compile-response-buffer'."
   (message "Recompile %s" src-file)
   (let ((coqc-arguments
          (nconc
@@ -118,15 +118,15 @@ Display errors in buffer `coq-compile-response-buffer'."
         coqc-status)
     (coq-init-compile-response-buffer
      (mapconcat 'identity (cons coq-compiler coqc-arguments) " "))
-    (if coq-debug-auto-compilation
+    (if coq--debug-auto-compilation
         (message "call coqc arg list: %s" coqc-arguments))
     (setq coqc-status
           (apply 'call-process
-                 coq-compiler nil coq-compile-response-buffer t coqc-arguments))
-    (if coq-debug-auto-compilation
+                 coq-compiler nil coq--compile-response-buffer t coqc-arguments))
+    (if coq--debug-auto-compilation
         (message "compilation %s exited with %s, output |%s|"
                  src-file coqc-status
-                 (with-current-buffer coq-compile-response-buffer
+                 (with-current-buffer coq--compile-response-buffer
                    (buffer-string))))
     (unless (eq coqc-status 0)
       (coq-display-compile-response-buffer)
@@ -178,7 +178,7 @@ OBJ have identical modification times."
           (progn
             (coq-seq-compile-library src)
             'just-compiled)
-        (if coq-debug-auto-compilation
+        (if coq--debug-auto-compilation
             (message "Skip compilation of %s" src))
         obj-time))))
 
@@ -202,7 +202,7 @@ function."
   (let ((result (gethash lib-obj-file coq-obj-hash)))
     (if result
         (progn
-          (if coq-debug-auto-compilation
+          (if coq--debug-auto-compilation
               (message "Checked %s already" lib-obj-file))
           result)
       ;; lib-obj-file has not been checked -- do it now
@@ -315,16 +315,16 @@ function returns () if MODULE-ID comes from the standard library."
     (if (stringp result)
         ;; Error handling: coq-seq-get-library-dependencies was not able to
         ;; translate module-id into a file name. We insert now a faked error
-        ;; message into coq-compile-response-buffer to make next-error happy.
+        ;; message into coq--compile-response-buffer to make next-error happy.
         (let ((error-message
                (format "Cannot find library %s in loadpath" module-id))
               (inhibit-read-only t))
-          ;; Writing a message into coq-compile-response-buffer for next-error
+          ;; Writing a message into coq--compile-response-buffer for next-error
           ;; does currently not work. We do have exact position information
           ;; about the span, but we don't know how much white space there is
           ;; between the start of the span and the start of the command string.
-          ;; Check that coq-compile-response-buffer is a valid buffer!
-          ;; (with-current-buffer coq-compile-response-buffer
+          ;; Check that coq--compile-response-buffer is a valid buffer!
+          ;; (with-current-buffer coq--compile-response-buffer
           ;;   (insert
           ;;    (format "File \"%s\", line %d\n%s.\n"
           ;;            (buffer-file-name (span-buffer span))

--- a/coq/coq-seq-compile.el
+++ b/coq/coq-seq-compile.el
@@ -212,7 +212,7 @@ function."
           (setq result '(0 0))
         (let* ((lib-src-file
                 (expand-file-name
-		 (coq-library-src-of-obj-file lib-obj-file)))
+		 (coq-library-src-of-vo-file lib-obj-file)))
                dependencies deps-mod-time)
           (if (file-exists-p lib-src-file)
               ;; recurse into dependencies now
@@ -260,7 +260,7 @@ therefore the customizations for `compile' do not apply."
     (let* ((local-compile-command coq-compile-command)
            (physical-dir (file-name-directory absolute-module-obj-file))
            (module-object (file-name-nondirectory absolute-module-obj-file))
-           (module-source (coq-library-src-of-obj-file module-object))
+           (module-source (coq-library-src-of-vo-file module-object))
            (requiring-file buffer-file-name))
       (mapc
        (lambda (substitution)
@@ -282,7 +282,7 @@ therefore the customizations for `compile' do not apply."
       (compilation-start local-compile-command)
       (coq-seq-lock-ancestor
        span
-       (coq-library-src-of-obj-file absolute-module-obj-file)))))
+       (coq-library-src-of-vo-file absolute-module-obj-file)))))
 
 (defun coq-seq-map-module-id-to-obj-file (module-id span &optional from)
   "Map MODULE-ID to the appropriate coq object file.

--- a/coq/coq-system.el
+++ b/coq/coq-system.el
@@ -393,8 +393,9 @@ project file (see `coq-project-filename') somewhere in the
 current directory or its parent directories.  If there is one,
 its contents are read and used to determine the arguments that
 must be given to coqtop.  In particular it sets the load
-path (including the -R lib options) (see `coq-load-path') ."
+path (including the -R lib options) (see `coq-load-path')."
   :type 'boolean
+  :safe 'booleanp
   :group 'coq)
 
 (defcustom coq-project-filename "_CoqProject"
@@ -411,6 +412,7 @@ variables may still be used to override the coq project file's
 configuration. .dir-locals.el files also work and override
 project file settings."
   :type 'string
+  :safe 'stringp
   :group 'coq)
 
 (defun coq-find-project-file ()

--- a/doc/ProofGeneral.texi
+++ b/doc/ProofGeneral.texi
@@ -4340,39 +4340,42 @@ Inserts ``End <section-name>.'' (this should work well with nested sections).
 @node Using the Coq project file
 @section Using the Coq project file
 
-Before starting the Coq process, one need to set @code{coqtop} options,
-in particular the -I and -R command that set the directories to have in
-the coq load path. You can use file variables (@ref{Using file
-variables}) as it was recommended on previous versions of ProofGeneral
-but there is now a better way. ProofGeneral knows how to extract this
-information from the Coq project file if there is one. The Coq project
-file must be named following variable `coq-project-filename' (default:
-@code{_CoqProject}) and be on the root directory of your development.
+The Coq project file is the recommended way to configure the Coq
+load path and the mapping of logical module names to physical
+file path'. The project file is typically named
+@code{_CoqProject} and must be located at the directory root of
+your Coq project. Proof General searches for the Coq project file
+starting at the current directory and walking the directory
+structure upwards. The Coq project file contains the common
+options (especially @code{-R}) and a list of the files of the
+project, see the Coq reference manual, Section 15.3, ``Creating a
+Makefile for Coq modules''.
 
-It should contain something like:
+The Coq project file should contain something like:
 
 @verbatim
 -R foo bar
 -I foo2
 -arg -foo3
+file.v
+bar/other_file.v
+...
 @end verbatim
 
-The intial use of this file is to be given to the @code{coq_makefile}
-tool to generate a Makefile (see Coq documentation for details). It is
-parsed by ProofGeneral to guess the command line option. In this example
-the command line built by Proofgeneral will be @code{coqtop -foo3 -R foo
-bar -I foo2}.
+Proof General only extracts the common options from the Coq
+project file and uses them for @code{coqtop} background
+processes as well as for @code{coqdep} and @code{coqc} when you use
+the auto compilation feature, @ref{Automatic Compilation in
+Detail}. For the example above, Proof General will start
+@code{coqtop -foo3 -R foo bar -I foo2}.
 
 @emph{Remarque:} @code{-arg} must be followed by one and only one option
 to pass to coqtop/coqc, use several @code{-arg} to issue several
-options. One per line (limitation of proofgeneral).
+options. One per line (limitation of Proof General).
 
-This is the recommended way of configuring coqtop options for coq
-compilation, CoqIde and Proofgeneral. Its main advantage is that it
-avoids duplicating informations between these three tools.
-
-For specific (and rare) per file configuration one can still use file
-variables (@ref{Using file variables}).
+For backward compatibility, one can also configure the load path
+with the option @code{coq-load-path}, but this is not compatible
+with @code{CoqIde} or @code{coq_makefile}.
 
 @menu
 * Changing the name of the coq project file::
@@ -4382,44 +4385,60 @@ variables (@ref{Using file variables}).
 @node Changing the name of the coq project file
 @subsection Changing the name of the coq project file
 
-One can change the name of the project file by:
+To change the name of the Coq project file, configure
+@code{coq-project-filename} (select menu @code{Proof-General ->
+Advanced -> Customize -> Coq} and scroll down to ``Coq Project
+Filename''). Customizing @code{coq-project-filename} this way
+will change the Coq project file name permanently and globally.
 
-(setq coq-project-filename "myprojectfile")
-
-or:
-
-(setq (make-local-variable 'coq-project-filename) "myprojectfile")
-
-If this is for a project, the best is probably to have a .dir-locals.el
-at the root of the project, as explained in  @ref{Using file
-variables}. This file should contain something like:
+If you only want to change the name of the Coq project file for
+one project you can set the option as local file variable,
+@ref{Using file variables}. This can be done either directly in
+every file or once for all files of a directory tree with a
+@code{.dir-local.el} file, @inforef{Directory Variables, ,emacs}.
+For this case, this file should contain
 
 @lisp
 ((coq-mode . ((coq-project-filename . "myprojectfile"))))
 @end lisp
 
-or equivalently:
+Documentation of the user option @code{coq-project-filename}:
 
-@lisp
-((coq-mode
-  .
-  ((eval
-    .
-    (progn 
-      (make-local-variable 'coq-project-filename)
-      (setq coq-project-filename  "myprojectfile"))))))
-@end lisp
+@c TEXI DOCSTRING MAGIC: coq-project-filename
+@defvar coq-project-filename 
+The name of coq project file.@*
+The coq project file of a coq developpement (Cf Coq documentation
+on "makefile generation") should contain the arguments given to
+coq_makefile. In particular it contains the -I and -R
+options (preferably one per line). If @samp{coq-use-coqproject} is
+t (default) the content of this file will be used by proofgeneral
+to infer the @samp{@code{coq-load-path}} and the @samp{@code{coq-prog-args}} variables
+that set the coqtop invocation by proofgeneral. This is now the
+recommended way of configuring the coqtop invocation. Local file
+variables may still be used to override the coq project file's
+configuration. .dir-locals.el files also work and override
+project file settings.
+@end defvar
+
 
 @node Disabling the coq project file mechanism
 @subsection Disabling the coq project file mechanism
 
-If the variable `coq-use-project-file' is nil, then Proofgeneral will
-not look at project file. therefore you can put this in your config file
-(.emacs) to disable the use of project file:
+To disable the Coq project file feature in Proof General, set
+@code{coq-use-project-file} to nil (select menu
+@code{Proof-General -> Advanced -> Customize -> Coq} and scroll
+down to ``Coq Use Project File'').
 
-@lisp
-(setq coq-use-project-file nil)
-@end lisp
+@c TEXI DOCSTRING MAGIC: coq-use-project-file
+@defvar coq-use-project-file 
+If t, when opening a coq file read the dominating _CoqProject.@*
+If t, when a coq file is opened, Proof General will look for a
+project file (see @samp{@code{coq-project-filename}}) somewhere in the
+current directory or its parent directories.  If there is one,
+its contents are read and used to determine the arguments that
+must be given to coqtop.  In particular it sets the load
+path (including the -R lib options) (see @samp{@code{coq-load-path}}).
+@end defvar
 
 You can also use the .dir-locals.el as above to configure this setting
 on a per project basis.
@@ -4457,15 +4476,17 @@ There are actually two implementations of the Recompilation
 feature. 
 
 @table @asis
-@item Synchronous single threaded compilation (stable)
-With synchronous compilation, coqdep and coqc are called
-synchronously for each Require command. Proof General is locked
-until the compilation finishes
-@item Parallel asynchronous compilation (experimental)
+@item Parallel asynchronous compilation (stable, default)
 With parallel compilation, coqdep and coqc are launched in the
 background and Proof General stays responsive during compilation.
 Up to `coq-max-background-compilation-jobs' coqdep and coqc
-processes may run in parallel.
+processes may run in parallel. Coq 8.5 quick compilation is
+supported with various modes, @ref{Quick compilation and .vio Files}.
+@item Synchronous single threaded compilation (obsolete)
+With synchronous compilation, coqdep and coqc are called
+synchronously for each Require command. Proof General is locked
+until the compilation finishes. Coq 8.5 quick compilation is not
+supported with synchronously compilation.
 @end table
 
 To enable the automatic compilation feature, you have to follow
@@ -4474,30 +4495,15 @@ these points:
 @itemize @bullet
 @item
 The option @code{coq-compile-before-require} must be
-turned on (menu @code{Coq -> Settings -> Compile Before Require}).
+turned on (menu @code{Coq -> Auto Compilation -> Compile Before Require}).
 @item 
-Nonstandard load path elements @emph{must} be configured in the
-option @code{coq-load-path}. @code{-I} options in
+Nonstandard load path elements @emph{must} be configured via a
+Coq project file (this is the recommended option),
+@ref{Using the Coq project file} or via
+option @code{coq-load-path}. @code{-I} or @code{-R} options in
 @code{coq-prog-name} or @code{coq-prog-args} must be deleted.
 @item
-In @code{coq-load-path} use strings @code{"dir"} for @code{-I}
-options and lists of two strings @code{("dir" "path")} for
-@code{-R "dir" -as "path"} (for more details see the
-documentation of `coq-load-path' or @ref{Customizing Coq Multiple
-File Support}).
-@item
-For a nonstandard compilation procedure and limited ML module
-support, @code{coq-compile-command} can be set to an external
-compilation command. For standard dependency analysis with
-@code{coqdep} and compilation with @code{coqc} the option
-@code{coq-compile-command} can be left empty. In this case Proof
-General calls @code{coqdep} and @code{coqc} as needed.
-@item
-The default compilation method is synchronous compilation. In
-order to experience parallel background compilation on all your
-CPU cores, 
-enable `coq-compile-parallel-in-background' (menu @code{Coq ->
-Settings -> Compile Parallel In Background}). Configure 
+Configure
 @code{coq-max-background-compilation-jobs} if you want to limit
 the number of parallel background jobs.
 @end itemize
@@ -4507,6 +4513,7 @@ the number of parallel background jobs.
 @menu
 * Automatic Compilation in Detail::
 * Locking Ancestors::
+* Quick compilation and .vio Files::
 * Customizing Coq Multiple File Support::
 * Current Limitations::
 @end menu
@@ -4528,51 +4535,24 @@ compilation finished.
 
 Proof General uses @code{coqdep} in order to translate the
 qualified identifiers in @code{Require} commands to coq library
-file names. Therefore, in Coq version prior to @code{8.3pl2},
-@code{Require Arith} works, while
-@code{Require Arith.Le} gives an error. The use of @code{coqdep}
-is also the reason
-why nonstandard load path elements must be configured in
-@code{coq-load-path}. 
+file names and to determine library dependencies. Because Proof
+General cannot know whether files are updated outside of Emacs,
+it checks for every @code{Require} command the complete
+dependency tree and recompiles files as necessary.
 
-Once the library file name has been determined, its dependencies
-must be checked and out-of-date files must be compiled. This can
-either be done internally, by Proof General itself, or by an
-external command. If @code{coq-compile-command} is the empty
-string, Proof General does dependency checking and compilation
-itself. Otherwise the command in @code{coq-compile-command} is
-started as an external process after substituting certain keys,
-@ref{Customizing Coq Multiple File Support}. 
-
-For an external compilation command Proof General uses the
-general compilation facilities of Emacs
-(@inforef{Compilation,,emacs}) with its own customization variables.
-The compilation command must be customized in
-@code{coq-compile-command} and the flag
-@code{coq-confirm-external-compilation} (menu @code{Coq ->
-Settings -> Confirm External Compilation})
-determines
-whether the user must confirm the compilation command. The output
-of the compilation appears then in the @code{*compilation*}
-buffer.
-
-When Proof General compiles itself, output is only shown in case
+Output from the compilation is only shown in case
 of errors. It then appears in the buffer
-@code{*coq-compile-response*}. With internal as well as with external
-compilation 
-one can use @code{C-x `} (bound to @code{next-error},
+@code{*coq-compile-response*}.
+One can use @code{C-x `} (bound to @code{next-error},
 @inforef{Compilation Mode,,emacs}) to jump to error locations.
-Note however, that @code{coqdep} does not produce error messages
-with location information, so @code{C-x `} cannot work for errors
-from @code{coqdep}.
+Sometimes the compilation commands do not produce error messages
+with location information, then @code{C-x `} does only work in a
+limited way.
 
-Proof General cannot know if some library files have been updated
-outside of Proof General, therefore, it must perform the
-dependency checking for each @code{Require} command. If the
-continuous confirmation of the external compilation commands
-becomes tedious, disable
-@code{coq-confirm-external-compilation} (see menu @code{Coq ->
-Settings}).
+For Coq version 8.5 or newer, the option @code{coq-compile-quick}
+controls how @code{-quick} and @code{.vio} files are used,
+@ref{Quick compilation and .vio Files}. This can also be
+configured in the menu @code{Coq -> Auto Compilation}.
 
 When a @code{Require} command causes a compilation of some files
 one may wish to save some buffers to disk beforehand. The option
@@ -4587,13 +4567,18 @@ between two implementations of internal compilation.
 
 @table @asis
 @item Synchronous single threaded compilation
-This is the stable version supported since Proof General version
+This is the old, now outdated version supported since Proof General
 4.1. This method starts coqdep and coqc processes one after each
 other in synchronous subprocesses. Your Emacs session will be
 locked until compilation finishes. Use @code{C-g} to interrupt
-compilation. 
+compilation. This method supports compilation via an external
+command (such as @code{make}), see option
+@code{coq-compile-command} in @ref{Customizing Coq Multiple File
+Support} below. Synchronous compilation does not support the
+quick compilation of Coq 8.5.
+
 @item Parallel asynchronous compilation
-This is the new version added in Proof General version 4.3. It
+This is the newer and default version added in Proof General version 4.3. It
 runs up to @code{coq-max-background-compilation-jobs} coqdep and
 coqc jobs in parallel in asynchronous subprocesses (or uses all
 your CPU cores if @code{coq-max-background-compilation-jobs}
@@ -4609,6 +4594,14 @@ file. If you have other commands between two Require commands or
 before the first Require, then you may see Proof General and Coq
 running in addition to `coq-max-background-compilation-jobs'
 compilation jobs.
+
+Depending on the setting of @code{coq-compile-quick} (which can
+also be set via menu @code{Coq -> Auto Compilation}) Proof
+General produces @code{.vio} or @code{.vo} files and deletes
+outdated @code{.vio} or @code{.vo} files to ensure Coq does not
+load outdated files. When @code{quick-and-vio2vo} is selected a
+vio2vo compilation starts when the @code{Require} command had
+been processed, @ref{Quick compilation and .vio Files}.
 
 Actually, even with this method, not everything runs
 asynchronously. To translate module identifiers from the Coq
@@ -4658,6 +4651,109 @@ benefit, as Require commands are usually on the top of each
 file.]
 
 
+@node Quick compilation and .vio Files
+@subsection Quick compilation and .vio Files
+
+Proof General supports quick compilation only with the parallel
+asynchronous compilation. There are 4 modes that can be
+configured with @code{coq-compile-quick} or by selecting one of
+the radio buttons in the @code{Coq -> Auto Compilation} menu.
+
+Use the default @code{no-quick}, if you have not yet switched to
+@code{Proof using}. Use @code{quick-no-vio2vo}, if you want quick
+recompilation without producing .vo files. Option
+@code{quick-and-vio2vo} recompiles with @code{-quick} as
+@code{quick-no-vio2vo} does, but schedules a vio2vo compilation
+for missing @code{.vo} files after a certain delay. Finally, use
+@code{ensure-vo} for only importing @code{.vo} files with
+complete universe checks.
+
+Note that with all of @code{no-quick}, @code{quick-no-vio2vo} and
+@code{quick-and-vio2vo} your development might be unsound because
+universe constraints are not fully present in @code{.vio} files.
+
+There are a few peculiarities of quick compilation in Coq 8.5
+that one should be aware of.
+
+@itemize
+@item
+Quick compilation runs noticeably slower when section
+variables are not declared via @code{Proof using}.
+@item
+Even when section variables are declared, quick compilation runs
+slower on very small files, probably because of the
+comparatively big size of the @code{.vio} files. You can speed up
+quick compilation noticeably by running on a RAM disk.
+@item
+If both, the @code{.vo} and the @code{.vio} files are present,
+Coq load the more recent one, regardless of whether
+@code{-quick}, and emits a warning when the @code{.vio} is more
+recent than the @code{.vo}.
+@item
+Under some circumstances, files compiled when only the
+@code{.vio} file of some library was present are not compatible
+with (other) files compiled when also the @code{.vo} file of that
+library was present, see Coq issue #5223 for details. As a rule
+of thumb one should run vio2vo compilation only before or after
+library loading.
+@item
+Apart from the previous point, Coq works fine when libraries are
+present as a mixture of @code{.vio} and @code{.vo} files. While
+@code{make} insists on building all prerequisites as either
+@code{.vio} or @code{.vo} files, Proof General just checks
+whether an up-to-date compiled library file is present.
+@item
+To ensure soundness, all library dependencies must be compiled as
+@code{.vo} files and loaded into one Coq instance.
+@end itemize
+
+Detailed description of the 4 modes:
+
+@table @code
+@item no-quick
+Compile outdated prerequisites without @code{-quick}, producing @code{.vo}
+files, but don't compile prerequisites for which an up-to-date
+@code{.vio} file exists. Delete or overwrite outdated @code{.vo} files.
+
+@item quick-no-vio2vo
+Compile outdated prerequisites with @code{-quick}, producing @code{.vio}
+files, but don't compile prerequisites for which an up-to-date
+@code{.vo} file exists. Delete or overwrite outdated @code{.vio} files.
+
+@item quick-and-vio2vo
+Same as @code{quick-no-vio2vo}, but start vio2vo processes for
+missing @code{.vo} files after a certain delay when library
+complication for the current queue region has finished. With this
+mode you might see asynchronous errors from vio2vo compilation
+while you are processing stuff far below the last require. vio2vo
+compilation is done on a subset of the available cores controlled
+by option @code{coq-compile-vio2vo-percentage}, @ref{Customizing
+Coq Multiple File Support}.
+
+@emph{Warning}: This mode does only work when you process require
+commands in batches. Slowly single-stepping through require's
+might lead to inconsistency errors when loading some libraries,
+see Coq issue #5223. To mitigate this risk, vio2vo compilation
+only starts after a certain delay after the last require command
+of the current queue region has been processed. This is
+controlled by @code{coq-compile-vio2vo-delay}, @ref{Customizing
+Coq Multiple File Support}.
+
+@item ensure-vo
+Ensure that all library dependencies are present as @code{.vo}
+files and delete outdated @code{.vio} files or @code{.vio} files
+that are more recent than the corresponding @code{.vo} file. This
+setting is the only one that ensures soundness.
+@end table
+
+The options @code{no-quick} and @code{ensure-vo} are compatible
+with Coq 8.4 or older. When Proof General detects such an older
+Coq version, it changes the quick compilation mode automatically.
+For this to work, the option @code{coq-compile-quick} must only
+be set via the customization system or via the menu.
+
+
+
 @node Customizing Coq Multiple File Support
 @subsection Customizing Coq Multiple File Support
 
@@ -4677,7 +4773,7 @@ required library module and its dependencies are up-to-date. If not, they
 are compiled from the sources before the "Require" command is processed.
 
 This option can be set/reset via menu
-@samp{Coq -> Settings -> Compile Before Require}.
+@samp{Coq -> Auto Compilation -> Compile Before Require}.
 @end defvar
 
 
@@ -4697,8 +4793,7 @@ confirmation.
 @end defvar
 
 
-The following two options are for the parallel compilation
-method.
+The following options configure parallel compilation.
 
 @c TEXI DOCSTRING MAGIC: coq-compile-parallel-in-background
 @defvar coq-compile-parallel-in-background 
@@ -4713,8 +4808,13 @@ the background. The maximal number of parallel compilation jobs
 is set with @samp{@code{coq-max-background-compilation-jobs}}.
 
 This option can be set/reset via menu
-@samp{Coq -> Settings -> Compile Parallel In Background}.
+@samp{Coq -> Auto Compilation -> Compile Parallel In Background}.
 @end defvar
+
+
+The option @code{coq-compile-quick} is described in detail above,
+@ref{Quick compilation and .vio Files}
+
 
 @c TEXI DOCSTRING MAGIC: coq-max-background-compilation-jobs
 @defvar coq-max-background-compilation-jobs 
@@ -4728,15 +4828,81 @@ is not adapted.
 @end defvar
 
 
-The following two options deal with the load path. Proof General
-divides the load path into the standard load path (which is
-hardwired in the tools and need not be set explicitly), the
-nonstandard load path (which must always be set explicitly), and
-the current directory (which must be set explicitly for
-@code{coqdep}). The option @code{coq-load-path} determines the
-nonstandard load path and @code{coq-load-path-include-current}
-determines whether the current directory is put into the load
-path of @code{coqdep}.
+@c TEXI DOCSTRING MAGIC: coq-max-background-vio2vo-percentage
+@defvar coq-max-background-vio2vo-percentage 
+Percentage of @samp{@code{coq-max-background-vio2vo-percentage}} for vio2vo jobs.@*
+This setting configures the maximal number of vio2vo background
+jobs (if you set @samp{@code{coq-compile-quick}} to @code{'quick-and-vio2vo}) as
+percentage of @samp{@code{coq-max-background-compilation-jobs}}.
+@end defvar
+
+
+@c TEXI DOCSTRING MAGIC: coq-compile-vio2vo-delay
+@defvar coq-compile-vio2vo-delay 
+Delay in seconds for the vio2vo compilation.@*
+This delay helps to avoid running into a library inconsistency
+with @code{'quick-and-vio2vo}, see Coq issue #@var{5223}.
+@end defvar
+
+Locking ancestors can be disabled with the following option.
+
+@c TEXI DOCSTRING MAGIC: coq-lock-ancestors
+@defvar coq-lock-ancestors 
+If non-nil, lock ancestor module files.@*
+If external compilation is used (via @samp{@code{coq-compile-command}}) then
+only the direct ancestors are locked. Otherwise all ancestors are
+locked when the "Require" command is processed.
+@end defvar
+
+
+The sequential compilation setting supports an external
+compilation command (which could be a parallel running
+@code{make}). For this set
+@code{coq-compile-parallel-in-background} to @code{nil} and
+configure the compilation command in @code{coq-compile-command}.
+
+@c TEXI DOCSTRING MAGIC: coq-compile-command
+@defvar coq-compile-command 
+External compilation command. If empty ProofGeneral compiles itself.@*
+If unset (the empty string) ProofGeneral computes the dependencies of
+required modules with coqdep and compiles as necessary. This internal
+dependency checking does currently not handle ML modules.
+
+If a non-empty string, the denoted command is called to do the
+dependency checking and compilation. Before executing this
+command the following keys are substituted as follows:
+@lisp
+  %p  the (physical) directory containing the source of
+      the required module
+  %o  the Coq object file in the physical directory that will
+      be loaded
+  %s  the Coq source file in the physical directory whose
+      object will be loaded
+  %q  the qualified id of the "Require" command
+  %r  the source file containing the "Require"
+@end lisp
+For instance, "make -C %p %o" expands to "make -C bar foo.vo"
+when module "foo" from directory "bar" is required.
+
+After the substitution the command can be changed in the
+minibuffer if @samp{@code{coq-confirm-external-compilation}} is t.
+@end defvar
+
+
+@c TEXI DOCSTRING MAGIC: coq-confirm-external-compilation
+@defvar coq-confirm-external-compilation 
+If set let user change and confirm the compilation command.@*
+Otherwise start the external compilation without confirmation.
+
+This option can be set/reset via menu
+@samp{Coq -> Settings -> Confirm External Compilation}.
+@end defvar
+
+
+The preferred way to configure the load path and the mapping of
+logical library names to physical file path is the Coq project
+file, @ref{Using the Coq project file}. Alternatively one can
+configure these things with the following options.
 
 @c TEXI DOCSTRING MAGIC: coq-load-path
 @defvar coq-load-path 
@@ -4786,82 +4952,12 @@ in @samp{@code{coq-load-path}}.
 This setting is only relevant with Coq < 8.5.
 @end defvar
 
-
-The following two options configure an external compilation
-process.
-
-
-@c TEXI DOCSTRING MAGIC: coq-compile-command
-@defvar coq-compile-command 
-External compilation command. If empty ProofGeneral compiles itself.@*
-If unset (the empty string) ProofGeneral computes the dependencies of
-required modules with coqdep and compiles as necessary. This internal
-dependency checking does currently not handle ML modules.
-
-If a non-empty string, the denoted command is called to do the
-dependency checking and compilation. Before executing this
-command the following keys are substituted as follows:
-@lisp
-  %p  the (physical) directory containing the source of
-      the required module
-  %o  the Coq object file in the physical directory that will
-      be loaded
-  %s  the Coq source file in the physical directory whose
-      object will be loaded
-  %q  the qualified id of the "Require" command
-  %r  the source file containing the "Require"
-@end lisp
-For instance, "make -C %p %o" expands to "make -C bar foo.vo"
-when module "foo" from directory "bar" is required.
-
-After the substitution the command can be changed in the
-minibuffer if @samp{@code{coq-confirm-external-compilation}} is t.
-@end defvar
-
-
-@c TEXI DOCSTRING MAGIC: coq-confirm-external-compilation
-@defvar coq-confirm-external-compilation 
-If set let user change and confirm the compilation command.@*
-Otherwise start the external compilation without confirmation.
-
-This option can be set/reset via menu
-@samp{Coq -> Settings -> Confirm External Compilation}.
-@end defvar
-
-
-Locking ancestors can be disabled with the following option.
-
-@c TEXI DOCSTRING MAGIC: coq-lock-ancestors
-@defvar coq-lock-ancestors 
-If non-nil, lock ancestor module files.@*
-If external compilation is used (via @samp{@code{coq-compile-command}}) then
-only the direct ancestors are locked. Otherwise all ancestors are
-locked when the "Require" command is processed.
-@end defvar
-
-
-The following option controls which warnings of @code{coqdep}
-are treated as errors.
-
-@c TEXI DOCSTRING MAGIC: coq-coqdep-error-regexp
-@defvar coq-coqdep-error-regexp 
-Regexp to match errors in the output of coqdep.@*
-coqdep indicates errors not always via a non-zero exit status,
-but sometimes only via printing warnings. This regular expression
-is used for recognizing error conditions in the output of
-coqdep (when coqdep terminates with exit status 0). Its default
-value matches the warning that some required library cannot be
-found on the load path and ignores the warning for finding a
-library at multiple places in the load path. If you want to turn
-the latter condition into an error, then set this variable to
-"^\*\*\* Warning".
-@end defvar
-
-
-The following two options do only influence the behaviour if
-Proof General does dependency checking and compilation itself.
-These options determine whether Proof General should descend into
-other Coq libraries and into the Coq standard library. 
+During library dependency checking Proof General does not dive
+into the Coq standard library or into libraries that are
+installed as user contributions. This stems from @code{coqdep},
+which does not output dependencies to these directories.
+The internal dependency check can also ignore additional
+libraries.
 
 @c TEXI DOCSTRING MAGIC: coq-compile-ignored-directories
 @defvar coq-compile-ignored-directories 
@@ -4872,84 +4968,25 @@ of the regular expressions in this list then ProofGeneral does
 neither compile this file nor check its dependencies for
 compilation. It makes sense to include non-standard coq library
 directories here if they are not changed and if they are so big
-that dependency checking takes noticeable time.
+that dependency checking takes noticeable time. The regular
+expressions in here are always matched against the .vo file name,
+regardless whether @samp{`-quick}' would be used to compile the file
+or not.
 @end defvar
-
-
-@c TEXI DOCSTRING MAGIC: coq-compile-ignore-library-directory
-@defvar coq-compile-ignore-library-directory 
-If non-nil, ProofGeneral does not compile modules from the coq library.@*
-Should be @samp{t} for normal coq users. If @samp{nil} library modules are
-compiled if their sources are newer.
-
-This option has currently no effect, because Proof General uses
-coqdep to translate qualified identifiers into library file names
-and coqdep does not output dependencies in the standard library.
-@end defvar
-
-
-The last three Emacs constants are internal parameters. They only
-need to be changed under very special, unforeseen circumstances.
-They can only be set in Emacs lisp code because they are no
-customizable user options.
-
-@c TEXI DOCSTRING MAGIC: coq-compile-substitution-list
-@defvar coq-compile-substitution-list 
-Substitutions for @samp{@code{coq-compile-command}}.@*
-Value must be a list of substitutions, where each substitution is
-a 2-element list. The first element of a substitution is the
-regexp to substitute, the second the replacement. The replacement
-is evaluated before passing it to @samp{@code{replace-regexp-in-string}}, so
-it might be a string, or one of the symbols @code{'physical-dir},
-@code{'module-object}, @code{'module-source}, @code{'qualified-id} and
-@code{'requiring-file}, which are bound to, respectively, the physical
-directory containing the source file, the Coq object file in
-@code{'physical-dir} that will be loaded, the Coq source file in
-@code{'physical-dir} whose object will be loaded, the qualified module
-identifier that occurs in the "Require" command, and the file
-that contains the "Require".
-@end defvar
-
-
-@c TEXI DOCSTRING MAGIC: coq-require-command-regexp
-@defvar coq-require-command-regexp 
-Regular expression matching Require commands in Coq.@*
-Should match "Require" with its import and export variants up to (but not
-including) the first character of the first required module. The required
-modules are matched separately with @samp{@code{coq-require-id-regexp}}
-@end defvar
-
-
-@c TEXI DOCSTRING MAGIC: coq-require-id-regexp
-@defvar coq-require-id-regexp 
-Regular expression matching one Coq module identifier.@*
-Should match precisely one complete module identifier and surrounding
-white space. The module identifier must be matched with group number 1.
-Note that the trailing dot in "Require A." is not part of the module
-identifier and should therefore not be matched by this regexp.
-@end defvar
-
 
 
 @node Current Limitations
 @subsection Current Limitations
 
-In the current release some aspects of multiple file support have
-not been implemented. The following points will hopefully
-be addressed at some stage.
-
 @itemize
 @item
-Support @code{Declare ML Module} commands.
+No support @code{Declare ML Module} commands.
 @item
-Increase precision when comparing modification times. Because of
-an Emacs limitation, modification time stamps of files have only a
-precision of 1 second. If several compiled Coq object files have
-been created in the same second, Proof General is optimistic and
-does not recompile. (Note that GNU make behaves the same on file
-systems that record time stamps only with a precision of 1
-second.) Emacs version 24.3 implements high precision time stamps
-on files.
+When a compiled library has the same time stamp as the source
+file, it is considered outdated. Some old file systems (for
+instance ext3) or Emacs before version 24.3 support only time
+stamps with one second granularity. On such configurations Proof
+General will perform some unnecessary compilations.
 @end itemize
 
 


### PR DESCRIPTION
Select "Quick compilation mode" in the Coq menu. See also documentation of coq-compile-quick, the and-vio2vo stuff is not yet there.

This is a first version, there are several things to polish. I am especially not happy about the menu, I would like to have the quick compilation point in the settings menu, close to parallel compilation. However, the menu machinery behind defpacustom does not support radio menus. Other things to polish:
- ~~disable the quick menu for sequential compilation~~
- ~~8.4 compatibility~~
- ~~compilation warnings~~
- ~~update documentation~~
- ~~CHANGES file entry~~
