### PR TITLE
Remove default absolute name from coq-prog-name (Fixes #76), but keep displaying…

### DIFF
--- a/coq/coq-system.el
+++ b/coq/coq-system.el
@@ -30,7 +30,8 @@ On Windows you might need something like:
   :group 'coq)
 
 (defcustom coq-prog-name
-  (proof-locate-executable "coqtop" t '("C:/Program Files/Coq/bin"))
+  (if (executable-find "coqtop") "coqtop"
+    (proof-locate-executable "coqtop" t '("C:/Program Files/Coq/bin")))
   "*Name of program to run as Coq. See `proof-prog-name', set from this.
 On Windows with latest Coq package you might need something like:
    C:/Program Files/Coq/bin/coqtop.opt.exe

--- a/coq/coq-system.el
+++ b/coq/coq-system.el
@@ -43,13 +43,15 @@ See also `coq-prog-env' to adjust the environment."
   :group 'coq)
 
 (defcustom coq-dependency-analyzer
-  (proof-locate-executable "coqdep" t '("C:/Program Files/Coq/bin"))
+  (if (executable-find "coqdep") "coqdep"
+    (proof-locate-executable "coqdep" t '("C:/Program Files/Coq/bin")))
   "Command to invoke coqdep."
   :type 'string
   :group 'coq)
 
 (defcustom coq-compiler
-  (proof-locate-executable "coqc" t '("C:/Program Files/Coq/bin"))
+  (if (executable-find "coqc") "coqc"
+    (proof-locate-executable "coqc" t '("C:/Program Files/Coq/bin")))
   "Command to invoke the coq compiler."
   :type 'string
   :group 'coq)

--- a/generic/proof-shell.el
+++ b/generic/proof-shell.el
@@ -293,8 +293,10 @@ process command."
 		(apply proof-guess-command-line (list name)))))
 
     (if proof-prog-name-ask
-	(setq proof-prog-name (read-shell-command "Run process: "
-						  proof-prog-name)))
+        ;; if this option is set, an absolute file name is better to show if possible
+	(let ((prog-name (locate-file proof-prog-name exec-path exec-suffixes 1)))
+          (setq proof-prog-name (read-shell-command "Run process: "
+						  prog-name))))
     (let
 	((proc (downcase proof-assistant)))
 


### PR DESCRIPTION
… it when asking for it.

Fixing #76 trying to satisfy everyone: tramp users, windows users and users switching coq versions often.

Basically use "coqtop" everywhere except if coqtop is found outside windows path.
Show the absolute filename when asking the proof-prog-name interactivelt.