### PR TITLE
Fixing #154.

### DIFF
--- a/coq/coq.el
+++ b/coq/coq.el
@@ -1218,6 +1218,15 @@ flag Printing All set."
     (remove-hook 'proof-assert-command-hook 'coq-adapt-printing-width)
     (remove-hook 'proof-retract-command-hook 'coq-reset-printing-width)))
 
+;; In case of nested proofs (which are announced as obsolete in future versions
+;; of coq) Coq does not show the goals of enclosing proof when closing a nested
+;; proof. This is coq's proof-shell-empty-action-list-command function which
+;; inserts a "Show" if the last command of an action list is a save command and
+;; there is more than one open proof before that save.
+(defun coq-empty-action-list-command (cmd)
+  (when (and (string-match coq-save-command-regexp-strict cmd)
+             (> (length coq-last-but-one-proofstack) 1))
+    (list "Show.")))
 
 (defpacustom auto-adapt-printing-width t
   "If non-nil, adapt automatically printing width of goals window.
@@ -1541,6 +1550,9 @@ Near here means PT is either inside or just aside of a comment."
         proof-goal-command "Goal %s. "
         proof-save-command "Save %s. "
         proof-find-theorems-command "Search %s. ")
+
+  (setq proof-shell-empty-action-list-command 'coq-empty-action-list-command)
+
 ;; FIXME da: Does Coq have a help or about command?
 ;;	proof-info-command "Help"
 

--- a/generic/proof-config.el
+++ b/generic/proof-config.el
@@ -1187,6 +1187,24 @@ If nil, use the whole of the output from the match on
   :type '(choice (const nil) regexp)
   :group 'proof-shell)
 
+(defcustom proof-shell-empty-action-list-command nil
+  "A function returning a list of commands (strings) to be sent
+to the prover when the last command in the queue has been
+performed. Typically to ask for some informational
+display (goals, etc).
+
+The function takes as argument the last command in the queue.
+
+NOTE 1: The commands will be tagged invisible, i.e. not related
+to a place in the buffer.
+
+NOTE 2: The commands should NOT have any effect on the state of
+the prover. Otherwise running the script outside pg would be
+inconsistent."
+  :type 'function
+  :group 'proof-shell)
+
+
 (defcustom proof-shell-eager-annotation-start nil
   "Eager annotation field start.  A regular expression or nil.
 An \"eager annotation indicates\" to Proof General that some following output

--- a/generic/proof-shell.el
+++ b/generic/proof-shell.el
@@ -1118,13 +1118,11 @@ contains only invisible elements for Prooftree synchronization."
                    (not (memq 'empty-action-list flags)))
           (let* ((cmd (mapconcat 'identity (nth 1 item) " "))
                 (extra-cmds (apply proof-shell-empty-action-list-command (list cmd)))
-                (dummy (message "extra-cmds = %S" extra-cmds))
                 ;; tag all new items with 'empty-action-list
                 (extra-items (mapcar (lambda (s) (proof-shell-action-list-item
                                                   s 'proof-done-invisible
                                                   (list 'invisible 'empty-action-list)))
-                                     extra-cmds))
-                 (dummy (message "extra-items = %S" extra-items)))
+                                     extra-cmds)))
             ;; action-list should be empty at this point
             (setq proof-action-list (append extra-items proof-action-list))))
 

--- a/generic/proof-shell.el
+++ b/generic/proof-shell.el
@@ -1110,6 +1110,24 @@ contains only invisible elements for Prooftree synchronization."
 	(setq cbitems (cons item
 			    (proof-shell-slurp-comments)))
 
+        ;; If proof-action-list is empty after removing the already
+        ;; processed actions and the last action was not already
+        ;; added by proof-shell-empty-action-list-command (prover
+        ;; specific), call it.
+        (when (and (null proof-action-list)
+                   (not (memq 'empty-action-list flags)))
+          (let* ((cmd (mapconcat 'identity (nth 1 item) " "))
+                (extra-cmds (apply proof-shell-empty-action-list-command (list cmd)))
+                (dummy (message "extra-cmds = %S" extra-cmds))
+                ;; tag all new items with 'empty-action-list
+                (extra-items (mapcar (lambda (s) (proof-shell-action-list-item
+                                                  s 'proof-done-invisible
+                                                  (list 'invisible 'empty-action-list)))
+                                     extra-cmds))
+                 (dummy (message "extra-items = %S" extra-items)))
+            ;; action-list should be empty at this point
+            (setq proof-action-list (append extra-items proof-action-list))))
+
 	;; This is the point where old items have been removed from
 	;; proof-action-list and where the next item has not yet been
 	;; sent to the proof assistant. This is therefore one of the


### PR DESCRIPTION
This an attempt at fixing #154.
It seems to work, I would like to discuss the interaction with @hendriktews 's proof-tree, of which I mimick the way of inserting invisible commands in the action-list (nice by the way).

Hendrik, can you have a look please? I wonder if I should insert my commands before or after yours in proof-shell-exec-loop. Both are "Show." but mine is not no-response.

We could also merge both insertion in a single generic (proof-shell-invisible-commands-after-advancing-command). Or we may not bother since xml-pg has a different approach anyway.

