### PR TITLE
[WIP] ELPA/MELPA support

### DIFF
--- a/coq/coq-abbrev.el
+++ b/coq/coq-abbrev.el
@@ -71,7 +71,7 @@
     ;; DA: how about above, just temporarily disable saving?
     (message "Coq default abbrevs loaded")))
 
-(unless noninteractive
+(unless (or noninteractive (bound-and-true-p byte-compile-current-file))
   (coq-install-abbrevs))
 ;;;;;
 

--- a/coq/coq-abbrev.el
+++ b/coq/coq-abbrev.el
@@ -98,7 +98,7 @@ It was constructed with `proof-defstringset-fn'.")
 
 ;; The coq menu partly built from tables
 
-;; Common part (scrit, response and goals buffers)
+;; Common part (script, response and goals buffers)
 (defconst coq-menu-common-entries
   `(
     ["Toggle 3 Windows Mode" proof-three-window-toggle
@@ -300,7 +300,7 @@ It was constructed with `proof-defstringset-fn'.")
     ["ML4PG" (coq-activate-ml4pg) :help "Activates ML4PG: machine-learning methods for Proof General"]
     ))
 
-(defpgdefault menu-entries
+(setq-default coq-menu-entries
   (append coq-menu-common-entries
   `(
     ""
@@ -338,12 +338,10 @@ It was constructed with `proof-defstringset-fn'.")
      ["help" coq-local-vars-list-show-doc t]
      ["Compile" coq-Compile t]))))
 
-(defpgdefault help-menu-entries
+(setq-default coq-help-menu-entries
   '(["help on setting prog name persistently for a file" 
      coq-local-vars-list-show-doc t]))
 
-(defpgdefault other-buffers-menu-entries coq-menu-common-entries)
-
-
+(setq-default coq-other-buffers-menu-entries coq-menu-common-entries)
 
 (provide 'coq-abbrev)

--- a/coq/coq-autotest.el
+++ b/coq/coq-autotest.el
@@ -16,7 +16,7 @@
   (defvar coq-compile-before-require nil))
 
 
-(unless noninteractive
+(unless (bound-and-true-p byte-compile-current-file)
 
   (pg-autotest start 'debug)
 

--- a/coq/coq-autotest.el
+++ b/coq/coq-autotest.el
@@ -10,11 +10,8 @@
 
 (require 'pg-autotest)
 
-(eval-when (compile)
-  (require 'proof-site)
-  (proof-ready-for-assistant 'coq)
-  (defvar coq-compile-before-require nil))
-
+(require 'proof-site)
+(defvar coq-compile-before-require)
 
 (unless (bound-and-true-p byte-compile-current-file)
 

--- a/coq/coq-compile-common.el
+++ b/coq/coq-compile-common.el
@@ -19,8 +19,8 @@
 (eval-when (compile)
   ;;(defvar coq-pre-v85 nil)
   (require 'compile)
-  (defvar coq-confirm-external-compilation nil); defpacustom
-  (defvar coq-compile-parallel-in-background nil) ; defpacustom
+  (defvar coq-confirm-external-compilation); defpacustom
+  (defvar coq-compile-parallel-in-background) ; defpacustom
   (proof-ready-for-assistant 'coq))     ; compile for coq
 
 

--- a/coq/coq-compile-common.el
+++ b/coq/coq-compile-common.el
@@ -32,7 +32,7 @@
 ;; coq-par-compile, respectively. However, the :initialization
 ;; function of a defcustom seems to be evaluated when reading the
 ;; defcustom form. Therefore, these functions must be defined already,
-;; when the defpacustum coq-compile-parallel-in-background is read.
+;; when the defcustom coq-compile-parallel-in-background is read.
 
 (defun coq-par-enable ()
   "Enable parallel compilation.
@@ -155,7 +155,7 @@ Ignore any quick setting for Coq versions before 8.5."
   :group 'coq
   :package-version '(ProofGeneral . "4.1"))
 
-(defpacustom compile-before-require nil
+(defcustom coq-compile-before-require nil
   "If non-nil, check dependencies of required modules and compile if necessary.
 If non-nil ProofGeneral intercepts \"Require\" commands and checks if the
 required library module and its dependencies are up-to-date. If not, they
@@ -167,7 +167,9 @@ This option can be set/reset via menu
   :safe 'booleanp
   :group 'coq-auto-compile)
 
-(defpacustom compile-parallel-in-background nil
+(proof-deftoggle coq-compile-before-require)
+
+(defcustom coq-compile-parallel-in-background nil
   "Choose the internal compilation method.
 When Proof General compiles itself, you have the choice between
 two implementations. If this setting is nil, then Proof General
@@ -182,8 +184,12 @@ This option can be set/reset via menu
 `Coq -> Auto Compilation -> Compile Parallel In Background'."
   :type 'boolean
   :safe 'booleanp
-  :group 'coq-auto-compile
-  :eval (coq-switch-compilation-method))
+  :group 'coq-auto-compile)
+
+(proof-deftoggle coq-compile-parallel-in-background)
+
+(defun coq-compile-parallel-in-background ()
+  (coq-switch-compilation-method))
 
 ;; defpacustom fails to call :eval during inititialization, see trac #456
 (coq-switch-compilation-method)
@@ -405,7 +411,7 @@ This option can be set via menu
 ;; define coq-lock-ancestors-toggle
 (proof-deftoggle coq-lock-ancestors)
 
-(defpacustom confirm-external-compilation t
+(defcustom coq-confirm-external-compilation t
   "If set let user change and confirm the compilation command.
 Otherwise start the external compilation without confirmation.
 

--- a/coq/coq-compile-common.el
+++ b/coq/coq-compile-common.el
@@ -15,14 +15,12 @@
 
 (require 'proof-shell)
 (require 'coq-system)
+(require 'compile)
 
 (eval-when (compile)
   ;;(defvar coq-pre-v85 nil)
-  (require 'compile)
   (defvar coq-confirm-external-compilation); defpacustom
-  (defvar coq-compile-parallel-in-background) ; defpacustom
-  (proof-ready-for-assistant 'coq))     ; compile for coq
-
+  (defvar coq-compile-parallel-in-background)) ; defpacustom
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/coq/coq-indent.el
+++ b/coq/coq-indent.el
@@ -22,7 +22,7 @@
 ;     (message "%.06f" (float-time (time-since time)))))
 
 (eval-when-compile
-  (defvar coq-script-indent nil))
+  (defvar coq-script-indent))
 
 (defconst coq-any-command-regexp
   (proof-regexp-alt-list coq-keywords))

--- a/coq/coq-local-vars.el
+++ b/coq/coq-local-vars.el
@@ -15,8 +15,8 @@
   (require 'cl))
 
 (eval-when (compile)
-  (defvar coq-prog-name nil)
-  (defvar coq-load-path nil))
+  (defvar coq-prog-name)
+  (defvar coq-load-path))
 
 
 ;;; Code:

--- a/coq/coq-par-compile.el
+++ b/coq/coq-par-compile.el
@@ -28,10 +28,7 @@
   (require 'proof-compat))
 
 (eval-when (compile)
-  (defvar queueitems)       ; dynamic scope in p-s-extend-queue-hook
-  (defvar coq-compile-before-require)       ; defpacustom
-  (defvar coq-compile-parallel-in-background) ; defpacustom
-  (defvar coq-confirm-external-compilation)); defpacustom
+  (defvar queueitems))       ; dynamic scope in p-s-extend-queue-hook
 
 (require 'coq-compile-common)
 

--- a/coq/coq-par-compile.el
+++ b/coq/coq-par-compile.el
@@ -28,10 +28,10 @@
   (require 'proof-compat))
 
 (eval-when (compile)
-  (defvar queueitems nil)       ; dynamic scope in p-s-extend-queue-hook
-  (defvar coq-compile-before-require nil)       ; defpacustom
-  (defvar coq-compile-parallel-in-background nil) ; defpacustom
-  (defvar coq-confirm-external-compilation nil)); defpacustom
+  (defvar queueitems)       ; dynamic scope in p-s-extend-queue-hook
+  (defvar coq-compile-before-require)       ; defpacustom
+  (defvar coq-compile-parallel-in-background) ; defpacustom
+  (defvar coq-confirm-external-compilation)); defpacustom
 
 (require 'coq-compile-common)
 

--- a/coq/coq-seq-compile.el
+++ b/coq/coq-seq-compile.el
@@ -19,10 +19,7 @@
   (require 'proof-compat))
 
 (eval-when (compile)
-  (defvar queueitems)       ; dynamic scope in p-s-extend-queue-hook
-  (defvar coq-compile-before-require)       ; defpacustom
-  (defvar coq-compile-parallel-in-background)       ; defpacustom
-  (defvar coq-confirm-external-compilation)); defpacustom
+  (defvar queueitems))       ; dynamic scope in p-s-extend-queue-hook
 
 (require 'coq-compile-common)
 

--- a/coq/coq-seq-compile.el
+++ b/coq/coq-seq-compile.el
@@ -19,10 +19,10 @@
   (require 'proof-compat))
 
 (eval-when (compile)
-  (defvar queueitems nil)       ; dynamic scope in p-s-extend-queue-hook
-  (defvar coq-compile-before-require nil)       ; defpacustom
-  (defvar coq-compile-parallel-in-background nil)       ; defpacustom
-  (defvar coq-confirm-external-compilation nil)); defpacustom
+  (defvar queueitems)       ; dynamic scope in p-s-extend-queue-hook
+  (defvar coq-compile-before-require)       ; defpacustom
+  (defvar coq-compile-parallel-in-background)       ; defpacustom
+  (defvar coq-confirm-external-compilation)); defpacustom
 
 (require 'coq-compile-common)
 

--- a/coq/coq-syntax.el
+++ b/coq/coq-syntax.el
@@ -9,14 +9,9 @@
 (require 'proof-syntax)
 (require 'proof-utils)                  ; proof-locate-executable
 (require 'coq-db)
+(require 'span)
 
-(eval-when-compile
-  (require 'span)
-  (defvar coq-goal-command-regexp nil)
-  (defvar coq-save-command-regexp-strict nil))
-
-
- ;;; keyword databases
+;;; keyword databases
 
 (defcustom coq-user-tactics-db nil
   "User defined tactic information.  See `coq-syntax-db' for

--- a/coq/coq-system.el
+++ b/coq/coq-system.el
@@ -16,8 +16,7 @@
 
 (eval-when-compile
   (require 'cl)
-  (require 'proof-compat)
-  (proof-ready-for-assistant 'coq))
+  (require 'proof-compat))
 
 (eval-when (compile)
   (defvar coq-prog-args)

--- a/coq/coq-system.el
+++ b/coq/coq-system.el
@@ -20,8 +20,8 @@
   (proof-ready-for-assistant 'coq))
 
 (eval-when (compile)
-  (defvar coq-prog-args nil)
-  (defvar coq-debug nil))
+  (defvar coq-prog-args)
+  (defvar coq-debug))
 
 (defcustom coq-prog-env nil
   "List of environment settings d to pass to Coq process.

--- a/coq/coq.el
+++ b/coq/coq.el
@@ -30,8 +30,7 @@
   (defvar coq-time-commands)        ; defpacustom
   (defvar coq-use-project-file t)        ; defpacustom
   (defvar coq-use-editing-holes)    ; defpacustom
-  (defvar coq-hide-additional-subgoals)
-  (proof-ready-for-assistant 'coq))     ; compile for coq
+  (defvar coq-hide-additional-subgoals))
 
 (require 'proof)
 (require 'coq-system)                   ; load path, option, project file etc.

--- a/coq/coq.el
+++ b/coq/coq.el
@@ -1205,7 +1205,7 @@ flag Printing All set."
 ;; we can remove this.
 (defun coq-set-auto-adapt-printing-width (&optional symb val); args are for :set compatibility
   "Function called when setting `auto-adapt-printing-width'"
-  (setq symb val)
+  (setq symb val) ;; FIXME this is wrong (it should be 'set', but it would set nil sometimes)
   (if coq-auto-adapt-printing-width
       (progn
         (add-hook 'proof-assert-command-hook 'coq-adapt-printing-width)

--- a/coq/coq.el
+++ b/coq/coq.el
@@ -306,27 +306,23 @@ See also `coq-hide-additional-subgoals'."
 ;; Derived modes
 ;;
 
-(eval-and-compile ;; FIXME: Why?
-  (define-derived-mode coq-shell-mode proof-shell-mode
-    "Coq Shell" nil
-    (coq-shell-mode-config)))
+(define-derived-mode coq-shell-mode proof-shell-mode
+  "Coq Shell" nil
+  (coq-shell-mode-config))
 
-(eval-and-compile ;; FIXME: Why?
-  (define-derived-mode coq-response-mode proof-response-mode
+(define-derived-mode coq-response-mode proof-response-mode
   "Coq Response" nil
-    (coq-response-config)))
+  (coq-response-config))
 
-(eval-and-compile ;; FIXME: Why?
-  (define-derived-mode coq-mode proof-mode "Coq"
-    "Major mode for Coq scripts.
+(define-derived-mode coq-mode proof-mode "Coq"
+  "Major mode for Coq scripts.
 
 \\{coq-mode-map}"
-    (coq-mode-config)))
+  (coq-mode-config))
 
-(eval-and-compile ;; FIXME: Why?
-  (define-derived-mode coq-goals-mode proof-goals-mode
-    "Coq Goals" nil
-    (coq-goals-mode-config)))
+(define-derived-mode coq-goals-mode proof-goals-mode
+  "Coq Goals" nil
+  (coq-goals-mode-config))
 
 ;; Indentation and navigation support via SMIE.
 

--- a/coq/coq.el
+++ b/coq/coq.el
@@ -19,18 +19,18 @@
   (require 'newcomment)
   (require 'etags)
   (unless (proof-try-require 'smie)
-    (defvar smie-indent-basic nil)
-    (defvar smie-rules-function nil))
-  (defvar proof-info nil)       ; dynamic scope in proof-tree-urgent-action
-  (defvar action nil)       ; dynamic scope in coq-insert-as stuff
-  (defvar string nil)       ; dynamic scope in coq-insert-as stuff
-  (defvar old-proof-marker nil)
-                         ; dynamic scoq in coq-proof-tree-enable-evar-callback
-  (defvar coq-auto-insert-as nil)    ; defpacustom
-  (defvar coq-time-commands nil)        ; defpacustom
+    (defvar smie-indent-basic)
+    (defvar smie-rules-function))
+  (defvar proof-info)       ; dynamic scope in proof-tree-urgent-action
+  (defvar action)       ; dynamic scope in coq-insert-as stuff
+  (defvar string)       ; dynamic scope in coq-insert-as stuff
+  (defvar old-proof-marker)
+                                        ; dynamic scoq in coq-proof-tree-enable-evar-callback
+  (defvar coq-auto-insert-as)    ; defpacustom
+  (defvar coq-time-commands)        ; defpacustom
   (defvar coq-use-project-file t)        ; defpacustom
-  (defvar coq-use-editing-holes nil)    ; defpacustom
-  (defvar coq-hide-additional-subgoals nil) ; defpacustom
+  (defvar coq-use-editing-holes)    ; defpacustom
+  (defvar coq-hide-additional-subgoals)
   (proof-ready-for-assistant 'coq))     ; compile for coq
 
 (require 'proof)
@@ -1199,7 +1199,7 @@ flag Printing All set."
 
 ;; Check
 (eval-when (compile)
-  (defvar coq-auto-adapt-printing-width nil)); defpacustom
+  (defvar coq-auto-adapt-printing-width)); defpacustom
 
 ;; Since Printing Width is a synchronized option in coq (?) it is retored
 ;; silently to a previous value when retracting. So we reset the stored width

--- a/easycrypt/easycrypt.el
+++ b/easycrypt/easycrypt.el
@@ -6,7 +6,6 @@
 ;; --------------------------------------------------------------------
 
 (require 'proof)
-(require 'pg-custom)
 (require 'easycrypt-syntax)
 (require 'easycrypt-hooks)
 (require 'easycrypt-abbrev)

--- a/etc/development-tips.txt
+++ b/etc/development-tips.txt
@@ -29,8 +29,11 @@ Top-level forms, or forms that appear at top-level after compilation
 these forms depend on runtime information, e.g., the value of
 proof-assistant symbol (proof-ass), they will produce the wrong result
 (symptom: unbound nil-foobar). Running `proof-ready-for-assistant' can
-be used to avoid this and optimise compilation.  Byte compiler also
-optimises some conditionals that appear constant, be wary.
+be used to avoid this and optimise compilation (CPC 2017-02-25: this
+sounds fishy: this document seems to assume that compilation is done in
+a separate instance of Emacs, but that's not what happens when with
+package.el.  Calling `proof-ready-for-assistant' at compile time will
+tie the rest of that Emacs session to a specific proof assistant).
 
 Finally, the compiler will warn over-eagerly (and ususally spuriously)
 about unknown functions.  Adding extra requires can get these to go

--- a/generic/pg-assoc.el
+++ b/generic/pg-assoc.el
@@ -16,13 +16,12 @@
 
 (require 'proof-utils)
 
-(eval-and-compile ; defines proof-universal-keys-only-mode-map at compile time
-  (define-derived-mode proof-universal-keys-only-mode fundamental-mode
-    proof-general-name "Universal keymaps only"
-    ;; Doesn't seem to supress TAB, RET
-    (suppress-keymap proof-universal-keys-only-mode-map 'all)
-    (proof-define-keys proof-universal-keys-only-mode-map
-		       proof-universal-keys)))
+(define-derived-mode proof-universal-keys-only-mode fundamental-mode
+  proof-general-name "Universal keymaps only"
+  ;; Doesn't seem to supress TAB, RET
+  (suppress-keymap proof-universal-keys-only-mode-map 'all)
+  (proof-define-keys proof-universal-keys-only-mode-map
+                     proof-universal-keys))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/generic/pg-pamacs.el
+++ b/generic/pg-pamacs.el
@@ -260,7 +260,7 @@ This macro also extends the `proof-assistant-settings' list."
   (eval-when-compile
     (if (boundp 'proof-assistant-symbol)
 	;; declare variable to compiler to prevent warnings
-	(eval `(defvar ,(proof-ass-sym name) nil "Dummy for compilation."))))
+	(eval `(defvar ,(proof-ass-sym name)))))
   `(proof-defpacustom-fn (quote ,name) (quote ,val) (quote ,args)))
 
 

--- a/generic/pg-pamacs.el
+++ b/generic/pg-pamacs.el
@@ -257,10 +257,6 @@ Additional properties in the ARGS prop list may include:
 		     askprefs message.
 
 This macro also extends the `proof-assistant-settings' list."
-  (eval-when-compile
-    (if (boundp 'proof-assistant-symbol)
-	;; declare variable to compiler to prevent warnings
-	(eval `(defvar ,(proof-ass-sym name)))))
   `(proof-defpacustom-fn (quote ,name) (quote ,val) (quote ,args)))
 
 

--- a/generic/pg-pamacs.el
+++ b/generic/pg-pamacs.el
@@ -155,6 +155,8 @@ Usage: (defpgdefault SYM VALUE)"
 ;;;###autoload
 (defun proof-defpacustom-fn (name val args)
   "As for macro `defpacustom' but evaluating arguments."
+  (unless (and proof-assistant (not (string= proof-assistant "")))
+    (error "No proof assistant defined"))
   (let (newargs setting evalform type descr)
     (while args
       (cond

--- a/generic/pg-response.el
+++ b/generic/pg-response.el
@@ -99,33 +99,21 @@ Internal variable, setting this will have no effect!")
   "List of GNU Emacs frame parameters for secondary frames.")
 
 (defun proof-multiple-frames-enable ()
-  ; special-display-regexps is obsolete, let us let it for a while and
-  ; remove it later
-  (unless (eval-when-compile (boundp 'display-buffer-alist))
-    (let ((spdres (cons
-		   pg-response-special-display-regexp
-		   proof-multiframe-parameters)))
-      (if proof-multiple-frames-enable
-	  (add-to-list 'special-display-regexps spdres)
-	(setq special-display-regexps
-	      (delete spdres special-display-regexps)))))
-  ; This is the current way to do it
-  (when (eval-when-compile (boundp 'display-buffer-alist))
-    (let
-	((display-buffer-entry
-	  (cons pg-response-special-display-regexp
-	    `((display-buffer-reuse-window display-buffer-pop-up-frame) .
-	      ((reusable-frames . t)
-	       (pop-up-frame-parameters
-		.
-		,proof-multiframe-parameters))))))
-      (if proof-multiple-frames-enable
-	  (add-to-list
-	   'display-buffer-alist
-	   display-buffer-entry)
-	;(add-to-list 'display-buffer-alist (proof-buffer-dislay))
-	(setq display-buffer-alist
-	      (delete display-buffer-entry display-buffer-alist)))))
+  (let
+      ((display-buffer-entry
+        (cons pg-response-special-display-regexp
+          `((display-buffer-reuse-window display-buffer-pop-up-frame) .
+            ((reusable-frames . t)
+             (pop-up-frame-parameters
+              .
+              ,proof-multiframe-parameters))))))
+    (if proof-multiple-frames-enable
+        (add-to-list
+         'display-buffer-alist
+         display-buffer-entry)
+      ;(add-to-list 'display-buffer-alist (proof-buffer-dislay))
+      (setq display-buffer-alist
+            (delete display-buffer-entry display-buffer-alist))))
   (proof-layout-windows))
 
 (defun proof-three-window-enable ()
@@ -521,9 +509,7 @@ and start at the first error."
 			  ;; Pop up a window.
 			  (display-buffer
                            proof-response-buffer
-                           (and (eval-when-compile
-                                  (boundp 'display-buffer-alist))
-                                proof-multiple-frames-enable
+                           (and proof-multiple-frames-enable
                                 (cons nil proof-multiframe-parameters))))))
 		  ;; Make sure the response buffer stays where it is,
 		  ;; and make sure source buffer is visible

--- a/generic/pg-user.el
+++ b/generic/pg-user.el
@@ -563,9 +563,9 @@ last use time, to discourage saving these into the users database."
 ;; NB: completion table is expected to be set when proof-script
 ;; is loaded!  Call `proof-script-add-completions' to update.
 
-(unless noninteractive ; during compilation
+(unless (bound-and-true-p byte-compile-current-file)
   (eval-after-load "completion"
-  '(proof-add-completions)))
+    '(proof-add-completions)))
 
 (defun proof-script-complete (&optional arg)
   "Like `complete' but case-fold-search set to proof-case-fold-search."

--- a/generic/proof-menu.el
+++ b/generic/proof-menu.el
@@ -10,23 +10,13 @@
 (require 'cl)				; mapcan
 
 ;;; Code:
-(eval-when (compile)
-  (defvar proof-assistant-menu nil) ; defined by macro in proof-menu-define-specific
-  (defvar proof-mode-map nil))
+(eval-when-compile
+  (defvar proof-assistant-menu)	  ; defined by macro in proof-menu-define-specific
+  (defvar proof-mode-map))
 
 (require 'proof-utils)    ; proof-deftoggle, proof-eval-when-ready-for-assistant
 (require 'proof-useropts)
 (require 'proof-config)
-
-
-    
-
-
-(eval-when-compile
-  (defvar proof-assistant-menu)	  ; defined by macro in proof-menu-define-specific
-  (defvar proof-mode-map))
-    
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/generic/proof-shell.el
+++ b/generic/proof-shell.el
@@ -1911,7 +1911,6 @@ Error messages are displayed as usual."
 ;; Proof General shell mode definition
 ;;
 
-;(eval-and-compile			; to define vars
 ;;;###autoload
 (define-derived-mode proof-shell-mode scomint-mode
   "proof-shell" "Proof General shell mode class for proof assistant processes"

--- a/generic/proof-site.el
+++ b/generic/proof-site.el
@@ -163,7 +163,7 @@ You can use customize to set this variable."
 (require 'proof-autoloads)
 
 (eval-when-compile
-  (defvar Info-dir-contents nil))
+  (defvar Info-dir-contents))
 
 ;; Add the info directory to the Info path
 (if (file-exists-p proof-info-directory) ; for safety

--- a/generic/proof-splash.el
+++ b/generic/proof-splash.el
@@ -264,7 +264,7 @@ binding to remove this buffer."
 (defun proof-splash-message ()
   "Make sure the user gets welcomed one way or another."
   (interactive)
-  (unless (or proof-splash-seen noninteractive)
+  (unless (or proof-splash-seen noninteractive (bound-and-true-p byte-compile-current-file))
     (if proof-splash-enable
 	(progn
 	  ;; disable ordinary emacs splash

--- a/generic/proof-useropts.el
+++ b/generic/proof-useropts.el
@@ -43,6 +43,7 @@ approximation we test whether proof-config is fully-loaded yet."
   (set-default sym value)
   (when (and
 	 (not noninteractive)
+	 (not (bound-and-true-p byte-compile-current-file))
 	 (featurep 'pg-custom)
 	 (featurep 'proof-config))
       (if (fboundp sym)

--- a/generic/proof.el
+++ b/generic/proof.el
@@ -26,7 +26,7 @@
 
 (require 'proof-site)			; site/prover config, global vars, autoloads
 
-(unless noninteractive
+(unless (or noninteractive (bound-and-true-p byte-compile-current-file))
   (proof-splash-message))		; welcome the user now.
 
 (require 'proof-compat)			; Emacs and OS compatibility

--- a/hol-light/hol-light-autotest.el
+++ b/hol-light/hol-light-autotest.el
@@ -8,14 +8,14 @@
 (eval-when-compile
   (require 'cl))
 
-(eval-when (compile)
+(eval-when-compile
   (require 'proof-site)
   (proof-ready-for-assistant 'coq)
   (defvar coq-compile-before-require nil))
 
 (require 'pg-autotest)
 
-(unless noninteractive
+(unless (bound-and-true-p byte-compile-current-file)
   
   (pg-autotest start 'debug)
   (pg-autotest log ".autotest.log")  ; convention

--- a/hol-light/hol-light-autotest.el
+++ b/hol-light/hol-light-autotest.el
@@ -8,10 +8,8 @@
 (eval-when-compile
   (require 'cl))
 
-(eval-when-compile
-  (require 'proof-site)
-  (proof-ready-for-assistant 'coq)
-  (defvar coq-compile-before-require nil))
+(require 'proof-site)
+(proof-ready-for-assistant 'hol-light)
 
 (require 'pg-autotest)
 

--- a/isar/isabelle-system.el
+++ b/isar/isabelle-system.el
@@ -73,6 +73,7 @@ unverified.  Otherwise, returns non-nil if isa-isabelle-command
 is surely an executable with full path."
   (interactive "p")
   (when (and (not noninteractive)
+             (not (bound-and-true-p byte-compile-current-file))
 	     (not proof-rsh-command)
 	     (or force
 		 isabelle-not-found
@@ -139,7 +140,7 @@ generated with the Lisp form `(isa-tool-list-logics)'."
   :type (list 'string)
   :group 'isabelle)
 
-(unless noninteractive
+(unless (or noninteractive (bound-and-true-p byte-compile-current-file))
   (setq isabelle-logics-available (isa-tool-list-logics)))
 
 (defcustom isabelle-chosen-logic nil
@@ -287,7 +288,7 @@ for you, you should disable this behaviour."
 				 :help (format "Switch to %s logic" l)))
 		       isabelle-logics-available)))))
 
-(unless noninteractive
+(unless (or noninteractive (bound-and-true-p byte-compile-current-file))
   (isabelle-logics-menu-calculate))
 
 (defvar isabelle-time-to-refresh-logics t

--- a/isar/isabelle-system.el
+++ b/isar/isabelle-system.el
@@ -16,13 +16,12 @@
   (require 'cl))			;  mapcan, eval-when
 
 (eval-when (compile)
-  (require 'span)		        
-  (require 'scomint)		        
+  (require 'span)
+  (require 'scomint)
   (require 'proof-site)
   (require 'proof-menu)
   (require 'proof-syntax)
-  (proof-ready-for-assistant 'isar)	; compile for isar
-  (defvar proof-assistant-menu nil))
+  (defvar proof-assistant-menu))
 
 (declare-function mapcan "cl-extra")	; spurious bytecomp warning
 

--- a/isar/isar-autotest.el
+++ b/isar/isar-autotest.el
@@ -20,7 +20,7 @@
 (declare-function isar-tracing:auto-solve-direct-toggle "isar.el")
 (declare-function isar-proof:parallel-proofs-toggle "isar.el")
 
-(unless noninteractive
+(unless (bound-and-true-p byte-compile-current-file)
 
   (pg-autotest start) ; can add 'debug flag for debug-on-error
 
@@ -89,10 +89,10 @@
   (pg-autotest script-randomjumps "isar/Example.thy" 8)
 
   (when isar-long-tests
-      (pg-autotest remark "Larger files...")
-      (pg-autotest script-wholefile "etc/isar/AHundredTheorems.thy")
-      (pg-autotest script-wholefile "isar/ex/Tarski.thy")
-      (pg-autotest script-randomjumps "isar/ex/Tarski.thy" 10)) ; better test?
+    (pg-autotest remark "Larger files...")
+    (pg-autotest script-wholefile "etc/isar/AHundredTheorems.thy")
+    (pg-autotest script-wholefile "isar/ex/Tarski.thy")
+    (pg-autotest script-randomjumps "isar/ex/Tarski.thy" 10)) ; better test?
 
 
   (pg-autotest remark "Testing restarting the prover")

--- a/isar/isar-autotest.el
+++ b/isar/isar-autotest.el
@@ -11,10 +11,10 @@
 (require 'pg-autotest)
 
 (eval-when (compile)
-  (require 'cl)
-  (require 'proof-site)
-  (proof-ready-for-assistant 'isar))
+  (require 'cl))
 
+(require 'proof-site)
+(proof-ready-for-assistant 'isar)
 
 (declare-function isar-tracing:auto-quickcheck-toggle "isar.el")
 (declare-function isar-tracing:auto-solve-direct-toggle "isar.el")

--- a/isar/isar-profiling.el
+++ b/isar/isar-profiling.el
@@ -8,9 +8,8 @@
 (eval-when-compile
   (require 'cl))
 
-(eval-when (compile)
-  (require 'proof-site)
-  (proof-ready-for-assistant 'isar))  
+(require 'proof-site)
+(proof-ready-for-assistant 'isar)
 
 (declare-function isar-tracing:auto-solve-toggle "isar.el")
 (declare-function isar-tracing:auto-quickcheck-toggle "isar.el")

--- a/isar/isar-profiling.el
+++ b/isar/isar-profiling.el
@@ -19,7 +19,7 @@
 (require 'pg-autotest)
 (require 'pg-dev)
 
-(unless noninteractive
+(unless (bound-and-true-p byte-compile-current-file)
 
   (pg-autotest log ".profile.log")  ; convention
 

--- a/isar/isar.el
+++ b/isar/isar.el
@@ -303,28 +303,24 @@ This is called when Proof General spots output matching
 ;;
 ;; use eval-and-compile to define vars for byte comp.
 
-(eval-and-compile
 (define-derived-mode isar-shell-mode proof-shell-mode
    "Isabelle Shell" nil
-   (isar-shell-mode-config)))
+   (isar-shell-mode-config))
 
-(eval-and-compile
 (define-derived-mode isar-response-mode proof-response-mode
   "Isar Messages" nil
-  (isar-response-mode-config)))
+  (isar-response-mode-config))
 
-(eval-and-compile
 (define-derived-mode isar-goals-mode proof-goals-mode
   "Isar Proofstate" nil
-  (isar-goals-mode-config)))
+  (isar-goals-mode-config))
 
-(eval-and-compile
 (define-derived-mode isar-mode proof-mode
   "Isar"
   "Major mode for editing Isar proof scripts.
 
 \\{isar-mode-map}"
-  (isar-mode-config)))
+  (isar-mode-config))
 
 
 

--- a/isar/isar.el
+++ b/isar/isar.el
@@ -25,10 +25,9 @@
   (require 'pg-goals)
   (require 'pg-vars)
   (require 'outline)
-  (defvar comment-quote-nested nil)
-  (defvar isar-use-find-theorems-form nil)
-  (defvar isar-use-linear-undo nil)
-  (proof-ready-for-assistant 'isar))	; compile for isar
+  (defvar comment-quote-nested)
+  (defvar isar-use-find-theorems-form)
+  (defvar isar-use-linear-undo))
 
 (require 'proof)
 (require 'isabelle-system)		; system code

--- a/lego/lego.el
+++ b/lego/lego.el
@@ -149,15 +149,14 @@ Activates extended printing routines required for Proof General.")
    (lego-shell-mode-config))
 
 (define-derived-mode lego-mode proof-mode
-   "lego" nil
-   (lego-mode-config))
+  "lego" nil
+  (lego-mode-config))
 
-(eval-and-compile
-  (define-derived-mode lego-response-mode proof-response-mode
-    "LEGOResp" nil
-    (setq proof-response-font-lock-keywords lego-font-lock-terms)
-    (lego-init-syntax-table)
-    (proof-response-config-done)))
+(define-derived-mode lego-response-mode proof-response-mode
+  "LEGOResp" nil
+  (setq proof-response-font-lock-keywords lego-font-lock-terms)
+  (lego-init-syntax-table)
+  (proof-response-config-done))
 
 (define-derived-mode lego-goals-mode proof-goals-mode
   "LEGOGoals" "LEGO Proof State"

--- a/lib/holes.el
+++ b/lib/holes.el
@@ -30,9 +30,7 @@
 ;;
 ;; See documentation of `holes-mode'.
 
-
-(eval-when-compile 
-  (require 'span))
+(require 'span)
 (require 'cl)
 
 ;;; Code:

--- a/lib/pg-fontsets.el
+++ b/lib/pg-fontsets.el
@@ -21,8 +21,7 @@
 
 ;;; Code:
 
-(eval-and-compile
-  (require 'fontset))			; needed for some emacsen without X
+(require 'fontset)
 
 (defcustom pg-fontsets-default-fontset nil
   "*Name of default fontset to use with Proof General."

--- a/lib/proof-compat.el
+++ b/lib/proof-compat.el
@@ -17,9 +17,7 @@
 ;; Since Proof General 4.0, XEmacs is not supported at all.
 ;;
 
-(eval-when-compile
-  (require 'easymenu))
-
+(require 'easymenu)
 (require 'cl)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/lib/unicode-tokens.el
+++ b/lib/unicode-tokens.el
@@ -45,11 +45,7 @@
 (require 'quail)
 
 (eval-when-compile
-  (require 'maths-menu)		; nuke compile warnings
-  ;; Emacs <24 compatibility
-  (when (and (fboundp 'flet)
-	     (not (get 'flet 'byte-obsolete-info)))
-    (defalias 'cl-flet 'flet)))
+  (require 'maths-menu))		; nuke compile warnings
 
 ;;
 ;; Customizable user options

--- a/obsolete/demoisa/demoisa-easy.el
+++ b/obsolete/demoisa/demoisa-easy.el
@@ -25,9 +25,8 @@
 ;; To test this file you must rename it demoisa.el.
 ;;
 
-(eval-and-compile
-  (require 'proof-site)			; compilation for demoisa
-  (proof-ready-for-assistant 'demoisa))
+(require 'proof-site)
+(proof-ready-for-assistant 'demoisa)
 
 (require 'proof)
 (require 'proof-easy-config)		; easy configure mechanism

--- a/pg-init.el
+++ b/pg-init.el
@@ -1,0 +1,56 @@
+;;; pg-init.el --- Init file used for compatibility with package.el and ELPA  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2017  Clément Pit-Claudel
+
+;; Author: Clément Pit-Claudel <clement.pitclaudel@live.com>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Proof General's initialization code (in generic/proof-site) is relatively
+;; complex, in part because it was written before package.el existed, and in
+;; part because package.el still doesn't look for autoloads in subdirectories.
+;; This file is a thin, package.el-friendly wrapper around generic/proof-site,
+;; suitable for execution on Emacs start-up.  It serves two purposes:
+;;
+;; * Setting up the load path when byte-compiling PG.
+;; * Loading a minimal PG setup on startup (not all of Proof General, of course;
+;;   mostly mode hooks and autoloads).
+
+;;; Code:
+
+;;;###autoload
+(eval-and-compile
+  (defvar pg-init--script-full-path
+    (or (and load-in-progress load-file-name)
+        (bound-and-true-p byte-compile-current-file)
+        (buffer-file-name)))
+  (defvar pg-init--pg-root
+    (file-name-directory pg-init--script-full-path)))
+
+;;;###autoload
+(unless (bound-and-true-p byte-compile-current-file)
+  ;; This require breaks compilation, so it must only run when loading the package.
+  (require 'proof-site (expand-file-name "generic/proof-site" pg-init--pg-root)))
+
+(eval-when-compile
+  (let ((byte-compile-directories
+         '("contrib/mmm" "generic" "lib"
+           "coq" "easycrypt" "pghaskell" "pgocaml" "pgshell")))
+    (dolist (dir byte-compile-directories)
+      (add-to-list 'load-path (expand-file-name dir pg-init--pg-root)))))
+
+(provide 'pg-init)
+;;; pg-init.el ends here

--- a/phox/phox-tags.el
+++ b/phox/phox-tags.el
@@ -18,9 +18,9 @@
 (require 'etags)
 
 (eval-when-compile
-  (defvar phox-doc-dir nil)
-  (defvar phox-lib-dir nil)
-  (defvar phox-etags nil))
+  (defvar phox-doc-dir)
+  (defvar phox-lib-dir)
+  (defvar phox-etags))
 
 
 (defun phox-tags-add-table(table)

--- a/phox/phox.el
+++ b/phox/phox.el
@@ -7,7 +7,7 @@
 ;; loaded).
 
 (eval-when-compile
-  (defvar phox-toolbar-entries nil))
+  (defvar phox-toolbar-entries))
 
 (eval-after-load "pg-custom"
   '(setq phox-toolbar-entries

--- a/proof-general-pkg.el
+++ b/proof-general-pkg.el
@@ -1,0 +1,2 @@
+(define-package "proof-general" "4.4.1~pre" "A generic front-end for proof assistants (interactive theorem provers)"
+  '((emacs "24.4")))


### PR DESCRIPTION
I finally found the time to look into ELPA/MELPA support.  Here's a brief summary of the issues that popped up:

* The current Makefile uses a fresh Emacs to compile each file.  On the other hand, package.el compiles all files in the same Emacs instance (the current one).  This means that the common pattern of running `(proof-ready-for-assistant …)`  in an `(eval-when-compile …)` wrapper doesn't work (it used to work because there was only one such for per file and each file was compiled in a fresh Emacs).

* There were uses of defpacustom and defpgdefault in files of the coq/ hierarchy that were `require`d by other files.  This only works *after* running `(proof-ready-for-assistant)` — without that, running `(defpacustom x …)` at load time just creates a variable called `nil-x`, because the proof assistant name isn't set.  But we can't run proof-ready-for-assistant, so I replaced these by `defcustom`s and `setq-default`.

* Some forms were `eval-and-compile`-d, without justification (and some had `;; FIXME Why?` near them; this includes `coq-mode`.  One comment mentioned ensuring that `…-mode-map` would be defined at compile time, but why would we want that?

* Autoloads are handled by `proof-site` for now (it loads `generic/pg-autoloads`).  How do we refresh that file? This connects to #128.

* PG had a pervasive assumption that noninteractive is set iif we're currently byte-compiling.  That assumption is wrong.

* There were a bunch of `(defvar … nil)` to silence the byte-compiler's warnings.  Isn't `(defvar …)` the proper form (no initializer)?

* I selected a subset of all directories for packaging.  I excluded the following: `bin etc obsolete previous-art  "acl2" "ccc" "hol-light" "hol98" "isar" "lego" "phox" "twelf"` (all the provers listed in there are marked as deprecated, except for isar).

* These changes add some compilation warnings, due to the byte-compiler not finding some symbols.  The normal way to do fix those be to `(require)` the appropriate files.  We can't do that, unfortunately, so instead we need to `(defvar …)` the relevant variables.  Help with this would be welcome.

Hopefull @Matafou and @erikmd can have a look (@hendriktews, if you have time to look at the compilation parts, that would be great too) :) To test, please clone https://github.com/cpitclaudel/melpa/, and run `make clean-sandbox recipes/proof-general sandbox`.  This opens a fresh Emacs in which you can run M-x package-install proof-general, and then open Coq files and see that everything works.  @strub, if you have time to test easycrypt support, that would be great too.

A careful review of the diffs would also be very welcome :) Thanks!