### PR TITLE
[Travis CI] Replace emacs-git target with emacs-25.{1,2} stable targets.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ env:
   - EMACS_TARGET=emacs-24.3
   - EMACS_TARGET=emacs-24.4
   - EMACS_TARGET=emacs-24.5
-  - EMACS_TARGET=emacs-git
+  - EMACS_TARGET=emacs-25.1
+  - EMACS_TARGET=emacs-25.2
 
 before_install:
   - make -f Makefile.travis before_install

--- a/Makefile.travis
+++ b/Makefile.travis
@@ -1,4 +1,4 @@
-VERSIONS = 21.4a 22.1 22.2 22.3 23.1 23.2b 23.3b 23.4 24.1 24.2 24.3 24.4 24.5
+VERSIONS = 24.1 24.2 24.3 24.4 24.5 25.1 25.2
 STABLE_TARGETS = $(addprefix prepare-emacs-,$(VERSIONS))
 
 .PHONY: prepare-emacs-24 prepare-emacs-git $(STABLE_TARGETS) \


### PR DESCRIPTION
Up to now the emacs-git Travis job was taking much more time w.r.t emacs24 (around 10min).
Now that emacs 25.1 and 25.2 has been released, I propose to build PG against them in place of emacs-git.
Hopefully this commit will shorten the real (elapsed) time of Travis CI automated build.