### PR TITLE
Fix easycrypt automode regexp

### DIFF
--- a/generic/proof-site.el
+++ b/generic/proof-site.el
@@ -39,7 +39,7 @@
 
       (isar "Isabelle" "thy")
       (coq "Coq" "v" nil (".vo" ".glob"))
-      (easycrypt "EasyCrypt" "ec" ".*\\.eca?")
+      (easycrypt "EasyCrypt" "ec" "\\.eca?\\'")
 
       ;; Obscure instances or conflict with other Emacs modes.
 


### PR DESCRIPTION
Without the string-end (`\\'`) it will match all file names which contain `.eca?`.