### PR TITLE
Default proof-prog-name-ask t

### DIFF
--- a/generic/proof-useropts.el
+++ b/generic/proof-useropts.el
@@ -254,7 +254,7 @@ files which are out of date with respect to the loaded buffers!"
   :group 'proof-user-options)
 
 (defcustom proof-prog-name-ask
-  nil
+  t
   "*If non-nil, query user which program to run for the inferior process."
   :type 'boolean
   :group 'proof-user-options)


### PR DESCRIPTION
This is probably better for security.

It also aligns with the Emacs compilation-read-command (which has a
similar role).