### PR TITLE
Add a missing parameter in advice on font-lock-fontify-keywords-region

### DIFF
--- a/generic/proof-syntax.el
+++ b/generic/proof-syntax.el
@@ -236,7 +236,7 @@ this were even more bogus...."
 (eval-after-load "font-lock"
 '(progn
 (defadvice font-lock-fontify-keywords-region
-  (before font-lock-fontify-keywords-advice (beg end loudly))
+  (before font-lock-fontify-keywords-advice (beg end &optional loudly))
   "Call proof assistant specific syntactic region fontify.
 If it's bound, we call <PA>-font-lock-fontify-syntactically-region."
   (when (and proof-buffer-type


### PR DESCRIPTION
This breaks various other modes in recent Emacs, most noticeably git-region-history:

Error during redisplay: (jit-lock-function 1501) signaled (wrong-number-of-arguments #[(ad--addoit-function beg end loudly) "\306	\203 \0\307\310\311
!\312\313Q!!\203 \0\310\311
!\312\313Q!#\210#\211)\207" [ad-return-value proof-buffer-type proof-assistant-symbol beg end loudly nil fboundp intern symbol-name "-" "font-lock-fontify-syntactically-region" ad--addoit-function] 6] 3)