### PR TITLE
Use non-remote path to expand paths in _CoqProject when file is remote.

### DIFF
--- a/coq/coq-system.el
+++ b/coq/coq-system.el
@@ -547,9 +547,11 @@ variable."
       (let* ((contents (with-current-buffer proj-file-buf (buffer-string)))
              (options (coq--read-options-from-project-file contents))
              (proj-file-name (buffer-file-name proj-file-buf))
-             (proj-file-dir (file-name-directory proj-file-name)))
+             (proj-file-dir (file-name-directory proj-file-name))
+             (proj-file-local-dir (or (file-remote-p proj-file-dir 'localname)
+                                      proj-file-dir)))
         (unless avoidargs (setq coq-prog-args (coq--extract-prog-args options)))
-        (unless avoidpath (setq coq-load-path (coq--extract-load-path options proj-file-dir)))
+        (unless avoidpath (setq coq-load-path (coq--extract-load-path options proj-file-local-dir)))
         (let ((msg
                (cond
                 ((and avoidpath avoidargs) "Coqtop args and load path")


### PR DESCRIPTION
When editing a remote file, the `coqtop` process will itself be remote, which means that the paths that are passed to it should be _local_, not remote. Otherwise, paths like `/ssh:hostname:/path/to/dir` get passed to `coqtop`, which has no idea what's going on.

I don't know elisp at all, so I'm not sure if there is a better way to write this, but it "seems to work" :) Also, I poked around at the TRAMP docs and couldn't find a more obvious way of doing this, though it seems like it should be a pretty common usecase (as anytime you want to pass arguments to something TRAMP has started, you want to do this renaming).

Also, this relates to (and should close) #203.