### PR TITLE
Ignore all ephemeral buffers and buffers not backed by a file

### DIFF
--- a/coq/coq-compile-common.el
+++ b/coq/coq-compile-common.el
@@ -678,9 +678,12 @@ from `coq-compile-save-some-buffers' to
 See also `save-some-buffers'.  Return t for buffers with major
 mode 'coq-mode' different from
 `coq-compile-buffer-with-current-require' and nil for all other
-buffers.  The buffer to test must be current."
+buffers. We will also return nil if the buffer is ephemeral, or
+not backed by a file. The buffer to test must be current."
   (and
    (eq major-mode 'coq-mode)
+   (not (string-prefix-p " " (buffer-name)))
+   buffer-file-name
    (not (eq coq-compile-buffer-with-current-require
             (current-buffer)))))
   


### PR DESCRIPTION
There's this really annoying problem where if you take notes in org-mode and have Coq source blocks, proof general will prompt to save the fontification buffers when running Import statements in Coq.

https://lists.gnu.org/archive/html/emacs-orgmode/2016-03/msg00354.html

This is a simple fix to ignore these buffers,