### PR TITLE
Improve use-package support

### DIFF
--- a/proof-general.el
+++ b/proof-general.el
@@ -14,10 +14,9 @@
 ;; Package-Requires: ((emacs "24.3"))
 ;; Version: 4.5-git
 
-;; This program is free software; you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
+;; This software is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; version 2, as published by the Free Software Foundation.
 
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/proof-general.el
+++ b/proof-general.el
@@ -1,4 +1,4 @@
-;;; pg-init.el --- PG init file for package.el and ELPA compatibility -*- lexical-binding:t; -*-
+;;; proof-general.el --- PG init file for package.el and ELPA compatibility -*- lexical-binding: t; -*-
 
 ;; This file is part of Proof General.
 
@@ -65,5 +65,5 @@
     (dolist (dir byte-compile-directories)
       (add-to-list 'load-path (expand-file-name dir root)))))
 
-(provide 'pg-init)
-;;; pg-init.el ends here
+(provide 'proof-general)
+;;; proof-general.el ends here

--- a/proof-general.el
+++ b/proof-general.el
@@ -9,7 +9,7 @@
 ;; Portions © Copyright 2011-2013, 2016-2017  Hendrik Tews
 ;; Portions © Copyright 2015-2017  Clément Pit-Claudel
 
-;; Author: Clément Pit-Claudel <clement.pitclaudel@live.com>
+;; Authors: (see the AUTHORS file distributed along the sources)
 ;; URL: https://proofgeneral.github.io/
 ;; Package-Requires: ((emacs "24.3"))
 ;; Version: 4.5-git
@@ -28,6 +28,21 @@
 
 ;;; Commentary:
 ;;
+;; Proof General is a generic Emacs interface for proof assistants
+;; (also known as interactive theorem provers).
+;;
+;; It is supplied ready to use for the proof assistants Coq,
+;; EasyCrypt, and PhoX.
+;;
+;; See https://proofgeneral.github.io/ for installation instructions
+;; and online documentation.  Or browse the accompanying info manual:
+;; (info-display-manual "ProofGeneral")
+;;
+;; Regarding the Coq proof assistant, you may be interested in the
+;; company-coq extension of ProofGeneral (also available in MELPA).
+
+;;; Code:
+
 ;; Proof General's initialization code (in generic/proof-site) is relatively
 ;; complex, in part because it was written before package.el existed, and in
 ;; part because package.el still doesn't look for autoloads in subdirectories.
@@ -37,8 +52,6 @@
 ;; * Setting up the load path when byte-compiling PG.
 ;; * Loading a minimal PG setup on startup (not all of Proof General, of course;
 ;;   mostly mode hooks and autoloads).
-
-;;; Code:
 
 ;;;###autoload
 (if t (require 'proof-site


### PR DESCRIPTION
This PR amounts to a trivial change (renaming), albeit necessary to simplify PG's setup using `use-package` as pointed out by @ejgallego in ProofGeneral/PG#398.

It also changes the `Commentary` text that will be displayed in http://www.melpa.org/#/proof-general (instead of `No description available.`)

FYI I have prepared a bootstrapped `.emacs` config in https://github.com/erikmd/tapfa-init.el for a course using Tuareg+Merlin+PG+company-coq starting on next Monday, and I'd like to simplify the `use-package` config of PG with this PR before the course starts.

So I plan to merge this on tomorrow Sunday Jan 13 at 12:00 +0100 or so, but if you have comments on the prose, feel free to comment! Cc @ProofGeneral/core  