### PR TITLE
Derive proof-mode from prog-mode

### DIFF
--- a/generic/proof-script.el
+++ b/generic/proof-script.el
@@ -2305,7 +2305,7 @@ query saves here."
 ;;
 
 ;;;###autoload
-(define-derived-mode proof-mode fundamental-mode
+(define-derived-mode proof-mode prog-mode
   proof-general-name
   "Proof General major mode class for proof scripts.
 \\{proof-mode-map}"


### PR DESCRIPTION
[prog-mode](https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/progmodes/prog-mode.el?id=a18336a8dc754fa1c68e16dd8009466cf409271b) is the base mode for programming that comes with Emacs: “All major modes for programming languages should derive from this mode so that users can put generic customization on `prog-mode-hook`.”