### PR TITLE
fix coqtags that can't find some theorem and output empty definition

### DIFF
--- a/coq/coqtags
+++ b/coq/coqtags
@@ -53,7 +53,7 @@ while(<>)
 
 #  print "----- (",$lp,",",$cp,")\n", $stmt, "\n";
 
-    if($stmt=~/^([ \t]*((Fact)|(Goal)|(Lemma)|(Remark)|(Theorem)|(Proposition)|(Corollary))\s+([\w\']+))\s*:/)
+    if($stmt=~/^([ \t]*((Fact)|(Goal)|(Lemma)|(Remark)|(Theorem)|(Proposition)|(Corollary))\s+([\w\']+)).*:/)
        { $tagstring.=$1."\177".$10."\001".$lp.",".$cp."\n"; }
 
     elsif($stmt=~/^([ \t]*((Axiom)|(Hypothesis)|(Parameter)|(Variable))\s+[\w\']+)/)
@@ -61,7 +61,7 @@ while(<>)
 
     elsif($stmt=~/^([ \t]*((Definition)|(Fixpoint)|(Inductive)|(CoInductive)|(Record)|(Variant))\s+([\w\']+))/)
     {
-	$tagstring.=$1."\177".$8."\001".$lp.",".$cp."\n";
+	$tagstring.=$1."\177".$9."\001".$lp.",".$cp."\n";
 	if($2 eq "Inductive" || $2 eq "CoInductive" || $2 eq "Variant"){
 	    add_constructors($stmt);
 	}


### PR DESCRIPTION
As the pull request name
1. The coqtags program can't find some Theorem/Lemma of the following form
```coq
Lemma lemma_name arg1 arg2 : T1 -> T2
```
2. It can't extract the defintion name
```coq
Definition d := true.
``` 
coqtags will output
```
Definition d^?^A1,1
```
The correct one should be
```
Definition d^?d^A1,1
```
I try to fix these two problems.
Thank you for this excellent tool