### PR TITLE
Make -topfile facility work for unnamed files

### DIFF
--- a/coq/coq-system.el
+++ b/coq/coq-system.el
@@ -432,7 +432,8 @@ LOADPATH, CURRENT-DIRECTORY, PRE-V85: see `coq-include-options'."
   "Build a list of options for coqc.
 LOADPATH, CURRENT-DIRECTORY, PRE-V85: see `coq-coqc-prog-args'."
   (append
-   (if (coq--supports-topfile) (cons "-topfile" (cons buffer-file-name nil)) "")
+   (if (and (coq--supports-topfile) buffer-file-name)
+       (cons "-topfile" (cons buffer-file-name nil)) "")
    (cons "-emacs" (coq-coqc-prog-args loadpath current-directory pre-v85))))
 
 (defun coq-prog-args ()


### PR DESCRIPTION
Currently, `-topfile` support of Coq PG doesn't work if `buffer-file-name` is `nil`, e.g., when proving in the `*scratch*` buffer. This PR changes it to do not use `-topfile` argument if `buffer-file-name` is `nil`.