### PR TITLE
Generic monadic indentation + specifically ext-lib / Compcert + doc.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -60,6 +60,22 @@ and the PG Trac http://proofgeneral.inf.ed.ac.uk/trac
     
     The set of tokens can be seen in variable smie-grammar.
 
+*** Indentation of monadic notations.
+    Using the extensibility for indentation described above we provide
+    a way to define your own monadic operators using the
+    coq-smie-monadic-tokens in the same spirit as coq-smie-user-tokens
+    above.
+
+    By default two well established syntax are supported:
+
+       x <- e ;;
+       e
+
+     and 
+
+       do x <- e ;
+       e
+
 *** Clickable Hypothesis in goals buffer to copy/paste hyp names
 
     Clicking on a hyp name in goals buffer with button 2 copies its

--- a/coq/ex/indent.v
+++ b/coq/ex/indent.v
@@ -5,6 +5,30 @@ Notation "[ a ; .. ; b ]" := (a :: .. (b :: []) ..) : list_scope.
 
 Require Import Arith.
 
+Definition arith1:
+  1 + 3 *
+      4.
+
+Definition arith2 :=
+  1 * 3 +
+  4.
+
+Definition logic1 :=
+  True \/ False /\
+          False.
+
+Definition logic2 :=
+  True /\ False \/
+  False.
+
+Definition logic3 :=
+  let x := True /\ False in True \/
+                            False .
+Definition logic4 :=
+  (let x := True /\ False in True) \/
+  False .
+
+
 Record a : Type := make_a {
                        aa : nat
                      }.

--- a/coq/ex/indent_monadic.v
+++ b/coq/ex/indent_monadic.v
@@ -1,0 +1,44 @@
+(* Needs ext-lib library to compile. *)
+
+Require Import Coq.ZArith.ZArith_base Coq.Strings.Ascii Coq.Strings.String.
+Require Import ExtLib.Data.Monads.StateMonad ExtLib.Structures.Monads.
+Import StringSyntax.
+Open Scope string_scope.
+Section StateGame.
+  
+  Check Ascii.Space.
+
+  Import MonadNotation.
+  Local Open Scope Z_scope.
+  Local Open Scope char_scope.
+  Local Open Scope monad_scope.
+
+  Definition GameValue : Type := Z.
+  Definition GameState : Type := (prod bool Z).
+
+  Variable m : Type -> Type.
+  Context {Monad_m: Monad m}.
+  Context {State_m: MonadState GameState m}.
+
+  Print Grammar constr.
+
+  Fixpoint playGame (s: string) m' {struct s}: m GameValue :=
+    match s with
+    |  EmptyString =>
+       v <- (if true then m' else get) ;;
+       let '(on, score) := v in ret score
+    |  String x xs =>
+       v <- get ;;
+       let '(on, score) := v in
+       match x, on with
+       | "a"%char, true =>  put (on, score + 1)
+       | "b"%char, true => put (on, score - 1)
+       | "c"%char, _ =>   put (negb on, score)
+       |  _, _  =>    put (on, score)
+       end ;;
+       playGame xs m'
+    end.
+
+  Definition startState: GameState := (false, 0).
+
+End StateGame.

--- a/doc/ProofGeneral.texi
+++ b/doc/ProofGeneral.texi
@@ -4300,6 +4300,7 @@ assistant.  It supports most of the generic features of Proof General.
 * Multiple File Support::
 * Editing multiple proofs::
 * User-loaded tactics::
+* Indentation tweaking::
 * Holes feature::
 * Proof-Tree Visualization::
 * Showing Proof Diffs::
@@ -5146,6 +5147,71 @@ move the locked region to the proper position,
 (@code{proof-frob-locked-end}, @pxref{Escaping script management}) or
 @kbd{C-c C-v} to re-issue an erroneously back-tracked tactic without
 recording it in the script.
+
+@node Indentation tweaking
+@section Indentation tweaking
+
+Indentation of Coq script is provided by Proof General, but it may
+behave badly especially if you use syntax extensions. You can sometimes
+fix this problem by telling PG that some token should be considered as
+identical to other ones by the indentation mechanism. Use the two
+variables @code{coq-smie-user-tokens} and
+@code{coq-smie-monadic-tokens}. This variables contains associations
+between user tokens and the existing pg tokens they should be equated
+too.
+
+@itemize @bullet
+@item @code{coq-smie-user-tokens}
+
+this is where users should put ther own tokens. For instance:
+
+@lisp
+(setq coq-smie-user-tokens '((\"xor\" . \"or\") (\"ifb\" . \"if\")))
+@end lisp
+to have token \"xor\" and \"ifb\" be considered as having
+@item @code{coq-smie-monadic-tokens}
+
+is specific to monadic operators: it contains usual monadic notations
+by default (but you can redefine it if needed).
+
+Specific tokens are defined for the two usual monadic forms: 
+
+@verbatim
+"let monadic" E "<- monadic" E "in monadic" E
+E "<- monadic" E ";; monadic" E
+@end verbatim
+
+The default value of @code{coq-smie-monadic-tokens} gives the following
+concrete syntax to these tokens:
+@lisp
+((";;" . ";; monadic")
+ ("do" . "let monadic")
+ ("<-" . "<- monadic")
+ (";" . "in monadic"))
+@end lisp
+
+thus allowing for the following:
+
+@verbatim
+  do x <- foo;
+  do y <- bar;
+  ...
+@end verbatim
+and
+@verbatim
+  x <- foo;;
+  y <- bar;;
+  ...
+@end verbatim
+@end itemize
+
+NOTE: This feature is experimental.
+
+NOTE: the ``pg tokens'' are actually the ones PG generates internally by
+exploring the file around the indentation point. Consequently this
+refers to internals of PoofGeneral. Contact the Proof General team if you
+need help.
+
 
 @node Holes feature
 @section Holes feature


### PR DESCRIPTION
This a generalization of PR#451 proposed by @Chobbes.

Since these syntax are not completely universal (and not builtin in
coq), the idea is to make the syntax customizable, especially to make
it possible to disable it.

NOTE: to make the Compcert syntax supported I had to refine the smie
lexer so that the ";" token was emitted as a fllback instead of ";
tactic".

NOTE2: I had to make the coq-user-token and coq-monadic-tokens be
tested ON THE RESULT of smie-coq-backward-token.