### PR TITLE
measure difference of silent and non-silent processing

### DIFF
--- a/generic/proof-shell.el
+++ b/generic/proof-shell.el
@@ -1026,6 +1026,7 @@ being processed."
 	  (nconc proof-action-list queueitems))
     
     (when nothingthere ; process comments immediately
+      (message "START PG QUEUE %s" (format-time-string "%H:%M:%S.%1N"))
       (let ((cbitems  (proof-shell-slurp-comments)))
 	(mapc 'proof-shell-invoke-callback cbitems)))
   
@@ -1184,6 +1185,8 @@ contains only invisible elements for Prooftree synchronization."
 	(unless (or proof-action-list proof-second-action-list-active)
 					; release lock, cleanup
 	  (proof-release-lock)
+          (message "END PG QUEUE %s"
+                   (format-time-string "%H:%M:%S.%1N")(current-time))
 	  (proof-detach-queue)
 	  (unless flags ; hint after a batch of scripting
 	    (pg-processing-complete-hint))


### PR DESCRIPTION
These are just two lines for measuring how long it takes to assert a block. The numbers show up in the *Messages* buffer. To see the difference between silent and non-silent processing, do it twice with and without proof-full-annotation set (also available in menu PG->Quick Options->Processing->Full Annotation).
I see 10.7 seconds for silent and 10.9 seconds for ≈3000 lines, without loading required modules.