### PR TITLE
Fix 464: proof-autoloads not found by Emacs

### DIFF
--- a/generic/pg-autotest.el
+++ b/generic/pg-autotest.el
@@ -45,7 +45,7 @@
 
 (defun pg-autotest-find-file (file)
   "Find FILE (relative to `proof-home-directory')."
-  (let* ((name   (concat proof-home-directory file)))
+  (let* ((name   (expand-file-name file proof-home-directory)))
     (if (file-exists-p name)
 	(find-file name)
       (error (format "autotest: requested file %s does not exist" name)))))

--- a/generic/pg-movie.el
+++ b/generic/pg-movie.el
@@ -43,7 +43,7 @@
   "<?xml-stylesheet type=\"text/xsl\" href=\"proviola-spp.xsl\"?>")
 
 (defun pg-movie-stylesheet-location ()
-  (concat proof-home-directory "etc/proviola/proviola-spp.xsl"))
+  (expand-file-name "etc/proviola/proviola-spp.xsl" proof-home-directory))
   
 
 (defvar pg-movie-frame 0 "Frame counter for movie.")


### PR DESCRIPTION
Patch proposed by @monnier to fix #464 .