### PR TITLE
doc/ProofGeneral.texi: fix makeinfo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,9 @@ jobs:
 
     - run: emacs --version
     - run: make
+    - name: Install makeinfo
+      run: sudo apt-get update -y -q && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends texinfo
+    - run: make doc.info
 
   test:
     runs-on: ubuntu-latest

--- a/doc/ProofGeneral.texi
+++ b/doc/ProofGeneral.texi
@@ -4294,6 +4294,7 @@ assistant.  It supports most of the generic features of Proof General.
 @menu
 * Coq-specific commands::
 * Using the Coq project file::
+* Proof using annotations::
 * Multiple File Support::
 * Editing multiple proofs::
 * User-loaded tactics::


### PR DESCRIPTION
Fixes the following error:

    node `Coq Proof General' lacks menu item for `Proof using annotations' despite being its Up target