### PR TITLE
Optional timeout warning when waiting for the proof shell

### DIFF
--- a/generic/proof-config.el
+++ b/generic/proof-config.el
@@ -1516,19 +1516,13 @@ outside of any proof.
   :type 'function
   :group 'proof-script)
 
-(defcustom proof-shell-timeout-warn-p t
-  "Whether Proof General should warn us if a command is taking
-too long and might be malformed.
+(defcustom proof-shell-timeout-warn 30
+  "How many seconds (integer) to wait before PG warns us that
+a command is taking a long time and might be malformed.
 
-Set to nil to disable."
-  :type 'boolean
-  :group 'proof-shell)
+Nil disables the timeout timer.
 
-(defcustom proof-shell-timeout-warn-length 30
-  "If `proof-shell-timeout-p' is true, this tells PG how long to
-wait before warning the user, in seconds.
-
-Default value is 30 seconds. Set it as an integer."
+Default value is 30 (seconds)."
   :type 'integer
   :group 'proof-shell)
 

--- a/generic/proof-config.el
+++ b/generic/proof-config.el
@@ -1516,7 +1516,21 @@ outside of any proof.
   :type 'function
   :group 'proof-script)
 
+(defcustom proof-shell-timeout-warn-p t
+  "Whether Proof General should warn us if a command is taking
+too long and might be malformed.
 
+Set to nil to disable."
+  :type 'boolean
+  :group 'proof-shell)
+
+(defcustom proof-shell-timeout-warn-length 30
+  "If `proof-shell-timeout-p' is true, this tells PG how long to
+wait before warning the user, in seconds.
+
+Default value is 30 seconds. Set it as an integer."
+  :type 'integer
+  :group 'proof-shell)
 
 ;;
 ;; 3c. tokens mode: turning on/off tokens output

--- a/generic/proof-script.el
+++ b/generic/proof-script.el
@@ -2029,9 +2029,9 @@ This function expects the buffer to be activated for advancing."
 
   ;; arm the timeout timer
   ;; cancelled in proof-shell-exec-loop unless proof-shell-busy
-  (if proof-shell-timeout-warn-p
+  (if proof-shell-timeout-warn
       (setq proof-shell-timer
-          (run-with-timer proof-shell-timeout-warn-length nil
+          (run-with-timer proof-shell-timeout-warn nil
                           'message "This command is taking a while. \
 Is it malformed? Do C-c C-c or C-c C-x to abort."))))
 

--- a/generic/proof-script.el
+++ b/generic/proof-script.el
@@ -2025,7 +2025,15 @@ This function expects the buffer to be activated for advancing."
 	(lastpos   (nth 2 (car semis)))
 	(vanillas  (proof-semis-to-vanillas semis displayflags)))
     (proof-script-delete-secondary-spans startpos lastpos)
-    (proof-extend-queue lastpos vanillas)))
+    (proof-extend-queue lastpos vanillas))
+
+  ;; arm the timeout timer
+  ;; cancelled in proof-shell-exec-loop unless proof-shell-busy
+  (if proof-shell-timeout-warn-p
+      (setq proof-shell-timer
+          (run-with-timer proof-shell-timeout-warn-length nil
+                          'message "This command is taking a while. \
+Is it malformed? Do C-c C-c or C-c C-x to abort."))))
 
 (defun proof-retract-before-change (beg end)
   "For `before-change-functions'.  Retract to BEG unless BEG and END in comment.

--- a/generic/proof-shell.el
+++ b/generic/proof-shell.el
@@ -149,6 +149,12 @@ This flag is set for the duration of `proof-shell-kill-function'
 to tell hooks in `proof-deactivate-scripting-hook' to refrain
 from calling `proof-shell-exit'.")
 
+(defvar proof-shell-timer nil
+  "A timer that alerts the user when the current command sent to the
+shell is taking too long and might be malformed. This is reset on entry
+of `proof-shell-exec-loop' and set when the next command is sent to
+the process. Disable by setting `proof-shell-timeout-p' to nil.
+Configure with `proof-shell-timeout-length'")
 
 
 ;;
@@ -1176,8 +1182,8 @@ contains only invisible elements for Prooftree synchronization."
 	  (proof-shell-handle-error-or-interrupt 'interrupt flags))
 
 	(if proof-action-list
-	    ;; send the next command to the process.
-	    (proof-shell-insert-action-item (car proof-action-list)))
+	  ;; send the next command to the process.
+	  (proof-shell-insert-action-item (car proof-action-list)))
 
 	;; process the delayed callbacks now
 	(mapc 'proof-shell-invoke-callback cbitems)

--- a/generic/proof-shell.el
+++ b/generic/proof-shell.el
@@ -1181,9 +1181,9 @@ contains only invisible elements for Prooftree synchronization."
 	  (setq cbitems nil)
 	  (proof-shell-handle-error-or-interrupt 'interrupt flags))
 
-	(if proof-action-list
-	  ;; send the next command to the process.
-	  (proof-shell-insert-action-item (car proof-action-list)))
+  (if proof-action-list
+	    ;; send the next command to the process.
+	    (proof-shell-insert-action-item (car proof-action-list)))
 
 	;; process the delayed callbacks now
 	(mapc 'proof-shell-invoke-callback cbitems)
@@ -1198,7 +1198,7 @@ contains only invisible elements for Prooftree synchronization."
 
   (unless proof-shell-busy
 		;; if the shell isn't still busy, cancel timer
-		(if (and proof-shell-timer proof-shell-timeout-warn-p)
+		(if (and proof-shell-timer proof-shell-timeout-warn)
 			(progn (cancel-timer proof-shell-timer)
 			       (setq proof-shell-timer nil))))
 

--- a/generic/proof-shell.el
+++ b/generic/proof-shell.el
@@ -1211,7 +1211,7 @@ contains only invisible elements for Prooftree synchronization."
 		;; if the shell isn't still busy, cancel timer
 		(if (and proof-shell-timer proof-shell-timeout-p)
 			(progn (cancel-timer proof-shell-timer)
-			       (setq proof-shell-timer nil)))
+			       (setq proof-shell-timer nil)))))
 
 
 (defun proof-shell-insert-loopback-cmd  (cmd)

--- a/generic/proof-shell.el
+++ b/generic/proof-shell.el
@@ -1196,6 +1196,12 @@ contains only invisible elements for Prooftree synchronization."
 	    (pg-processing-complete-hint))
 	  (pg-finish-tracing-display))
 
+  (unless proof-shell-busy
+		;; if the shell isn't still busy, cancel timer
+		(if (and proof-shell-timer proof-shell-timeout-warn-p)
+			(progn (cancel-timer proof-shell-timer)
+			       (setq proof-shell-timer nil))))
+
 	(and (not proof-second-action-list-active) 
 	     (let ((last-command  (car (nth 1 (car (last proof-action-list))))))
 	       (or (null proof-action-list)
@@ -1205,13 +1211,7 @@ contains only invisible elements for Prooftree synchronization."
 	 	   ;; If the last command in proof-action-list is a "Show Proof" form then return t
 	 	   (when last-command
              (proof-shell-string-match-safe
-              proof-show-proof-diffs-regexp last-command))))))))
-
-	(unless proof-shell-busy
-		;; if the shell isn't still busy, cancel timer
-		(if (and proof-shell-timer proof-shell-timeout-p)
-			(progn (cancel-timer proof-shell-timer)
-			       (setq proof-shell-timer nil)))))
+              proof-show-proof-diffs-regexp last-command)))))))))
 
 
 (defun proof-shell-insert-loopback-cmd  (cmd)

--- a/generic/proof-shell.el
+++ b/generic/proof-shell.el
@@ -1205,7 +1205,13 @@ contains only invisible elements for Prooftree synchronization."
 	 	   ;; If the last command in proof-action-list is a "Show Proof" form then return t
 	 	   (when last-command
              (proof-shell-string-match-safe
-              proof-show-proof-diffs-regexp last-command)))))))))
+              proof-show-proof-diffs-regexp last-command))))))))
+
+	(unless proof-shell-busy
+		;; if the shell isn't still busy, cancel timer
+		(if (and proof-shell-timer proof-shell-timeout-p)
+			(progn (cancel-timer proof-shell-timer)
+			       (setq proof-shell-timer nil)))
 
 
 (defun proof-shell-insert-loopback-cmd  (cmd)


### PR DESCRIPTION
With bad tactics in Coq (#514), Proof General will hang forever (but can be interrupted with `C-c C-c` or `C-c C-x`). In response to @hendriktews's workaround suggestion, this PR exposes a variable `proof-shell-timeout-warn` that, if an integer, enables a minibuffer warning after waiting on the proof shell for more than `proof-shell-timeout-warn` seconds. 

It doesn't fix the core issue, but the minibuffer warning will remind users of using `C-c C-c` and `C-c C-x` to cancel scripting. 

The text of the warning is "This command is taking a while. Is it malformed? Do C-c C-c or C-c C-x to abort." Default timeout is 30 seconds. 