### PR TITLE
Fix #514 + support for named goal selector.

### DIFF
--- a/coq/coq.el
+++ b/coq/coq.el
@@ -457,20 +457,6 @@ This is a subroutine of `proof-shell-filter'."
     (pg-response-display-with-face strnotrailingspace))) ; face
 
 
-;; Trying to accept { and } as terminator for empty commands. Actually
-;; I am experimenting two new commands "{" and "}" (without no
-;; trailing ".") which behave like BeginSubProof and EndSubproof. The
-;; absence of a trailing "." makes it difficult to distinguish between
-;; "{" of normal coq code (implicits, records) and this the new
-;; commands. We therefore define a coq-script-parse-function to this
-;; purpose.
-
-;; coq-end-command-regexp is ni coq-indent.el
-(defconst coq-script-command-end-regexp coq-end-command-regexp)
-;;        "\\(?:[^.]\\|\\(?:\\.\\.\\)\\)\\.\\(\\s-\\|\\'\\)")
-
-
-
 ;; slight modification of proof-script-generic-parse-cmdend (one of the
 ;; candidate for proof-script-parse-function), to allow "{" and "}" to be
 ;; command terminator when the command is empty. TO PLUG: swith the comment
@@ -1913,7 +1899,8 @@ at `proof-assistant-settings-cmds' evaluation time.")
   ;; coq-mode colorize errors better than the generic mechanism
   (setq proof-script-color-error-messages nil)
   (setq proof-terminal-string ".")
-  (setq proof-script-command-end-regexp coq-script-command-end-regexp)
+  ;; superseded by coq-script-parse-function
+  ;;(setq proof-script-command-end-regexp coq-script-command-end-regexp)
   (setq proof-script-parse-function 'coq-script-parse-function)
   (setq proof-script-comment-start comment-start)
   (setq proof-script-comment-end comment-end)
@@ -2741,8 +2728,6 @@ built from the list of strings in SUGGESTED."
   (lambda (span) (coq-insert-proof-using-suggestion span))
   "Coq specific dependency mechanism.
 Used for automatic insertion of \"Proof using\" annotations.")
-
-;::::::::::::: inserting suggested Proof using XXX... ;;;;;;;;;;
 
 
 (defun coq-insert-as-in-next-command ()

--- a/coq/ex/indent.v
+++ b/coq/ex/indent.v
@@ -4,8 +4,8 @@ Notation "[ ]" := nil : list_scope.
 Notation "[ a ; .. ; b ]" := (a :: .. (b :: []) ..) : list_scope.
 
 Require Import Arith.
-
-Definition arith1:
+Open Scope nat_scope.
+Definition arith1:=
   1 + 3 *
       4.
 
@@ -190,6 +190,27 @@ Module M1.
   End M2.
 End M1.
 
+Module GoalSelectors.
+  Theorem lt_n_S : (True \/ True \/ True \/ True \/ True ) -> True.
+  Proof.
+    refine (or_ind ?[aa] (or_ind ?[bb] (or_ind ?[cc] (or_ind ?[dd] ?[ee])))).
+    [aa]:{ auto. }
+    2:{  auto. }
+    [ee]:auto.
+    {  auto.}
+  Qed.
+  (* Same without space between "." and "}". *)
+  Theorem lt_n_S2 : (True \/ True \/ True \/ True \/ True ) -> True.
+  Proof.
+    refine (or_ind ?[aa] (or_ind ?[bb] (or_ind ?[cc] (or_ind ?[dd] ?[ee])))).
+    [aa]:{ auto.}
+    2:{  auto.}
+    [ee]:auto.
+    {  auto.}
+  Qed.
+
+
+End GoalSelectors.
 
 Module M1'.
   Module M2'.


### PR DESCRIPTION
It was hard to separate this 2 fixes (same regexps). Note in that in some cases pg still hangs, for instance `auto.{ }` makes it hang. I will try to make this better if I find some time. Not high priority though, we cannot deal with all possible ways of making a dynamic parser win against regexp.

Fixing windows issue with signals is beyond my ability. 

While at playing with regexp I implemented the support for named subgoals. Typical example of what is supported now:

```coq
Theorem lt_n_S : (True \/ True \/ True \/ True \/ True ) -> True.
Proof using Type with (auto).
  refine (or_ind ?[aa] (or_ind ?[bb] (or_ind ?[cc] (or_ind ?[dd] ?[ee])))).
  [aa]:{ intro. auto. }
  2:{  intro... }
  [ee]:{auto.}
  [dd]:{  auto. }
  auto.
Qed.
```

Command splitting and indentation seem OK.

Incidentally also fixed the `.}` mismatch between pg and coq (coq supports `{auto.}` which is a case where a dot not followed by a space is actually an ending dot). 
