### PR TITLE
Fix byte compilation

### DIFF
--- a/proof-general.el
+++ b/proof-general.el
@@ -56,8 +56,9 @@
 ;;;###autoload
 (eval-and-compile
   (defvar pg-init--script-full-path
-    (or (and load-in-progress load-file-name)
-        (bound-and-true-p byte-compile-current-file)
+    (or (bound-and-true-p byte-compile-current-file)
+        (and load-in-progress load-file-name)
+
         (buffer-file-name)))
   (defvar pg-init--pg-root
     (file-name-directory pg-init--script-full-path)))


### PR DESCRIPTION
load-file-name is not set to pg's source when compiling from doom-emacs

https://github.com/hlissner/doom-emacs/issues/2788