### PR TITLE
Workaround & Document debbug 34341 (fixed in Emacs 26.3, 27.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,20 @@ your `.emacs` and restart Emacs:
 
 ```elisp
 (require 'package)
-(let* ((no-ssl (and (memq system-type '(windows-nt ms-dos))
-                    (not (gnutls-available-p))))
-       (proto (if no-ssl "http" "https")))
-  (add-to-list 'package-archives
-               (cons "melpa" (concat proto "://melpa.org/packages/")) t))
+;; (setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3") ; see remark below
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
 (package-initialize)
 ```
+
+**Remark:** If you have Emacs 26.1 (which is precisely
+[the packaged version in Debian 10](https://packages.debian.org/emacs)),
+you may get the error message `Failed to download 'melpa' archive`
+during the package refresh step. This is a know bug
+([debbug #34341](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=34341))
+which has been fixed in Emacs 26.3 and 27.1, while a simple workaround
+consists in uncommenting the line
+`(setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3")` above in your
+`.emacs`.
 
 **Note:** If you switch to MELPA from a previously manually-installed
 Proof General, make sure you removed the old versions of Proof General

--- a/ci/init-tests.el
+++ b/ci/init-tests.el
@@ -9,6 +9,7 @@
 
 ;; Setup MELPA
 (require 'package)
+(setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3")
 (let* ((no-ssl (and (memq system-type '(windows-nt ms-dos))
                     (not (gnutls-available-p))))
        (proto (if no-ssl "http" "https")))

--- a/ci/init-tests.el
+++ b/ci/init-tests.el
@@ -10,11 +10,7 @@
 ;; Setup MELPA
 (require 'package)
 (setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3")
-(let* ((no-ssl (and (memq system-type '(windows-nt ms-dos))
-                    (not (gnutls-available-p))))
-       (proto (if no-ssl "http" "https")))
-  (add-to-list 'package-archives
-               (cons "melpa" (concat proto "://melpa.org/packages/")) t))
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
 (package-initialize)
 
 ;; Optionally: bootstrap use-package for declarative package specs


### PR DESCRIPTION
* **Kind**: fix/test
* Close #529
* This patch fixes ProofGeneral's CI test suite (which was failing because of Emacs 26.1)
* See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=34341 for details
* See also https://github.com/coq/coq/issues/12088#issuecomment-613522676