### PR TITLE
test: Add Emacs 27.1 in CI & Bump the minimal-required version of Emacs (24.5 for now)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,15 +17,15 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 24.3
-          - 24.4
           - 24.5
+          # 24.5 to be removed at End-of-Support of Ubuntu 16.04 LTS (https://wiki.ubuntu.com/Releases)
           - 25.1
           - 25.2
           - 25.3
           - 26.1
           - 26.2
           - 26.3
+          - 27.1
       # at most 20 concurrent jobs per free account
       # cf. https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#usage-limit
       max-parallel: 4
@@ -41,6 +41,7 @@ jobs:
 
     - run: emacs --version
     - run: make
+    # Erik: Extend this with linting?
     - name: Install makeinfo
       run: sudo apt-get update -y -q && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends texinfo
     - run: make doc.info

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Two editions of Proof General are currently available:
 
 ## Installing Proof General
 
+Proof General requires GNU Emacs `24.5` or later.
+
+The current policy aims at supporting multiple Emacs versions,
+including those available in [Debian Stable](https://packages.debian.org/stable/emacs)
+as well as in [Ubuntu LTS](https://packages.ubuntu.com/emacs24) distributions
+until their [End-Of-Support](https://wiki.ubuntu.com/Releases).
+
 ### Using MELPA (recommended procedure)
 
 [MELPA](https://melpa.org/) is a repository of Emacs packages. Skip

--- a/doc/ProofGeneral.texi
+++ b/doc/ProofGeneral.texi
@@ -58,8 +58,8 @@
 @c
 
 @set version 4.5-git
-@set emacsversion 24.3
-@set last-update September 2016
+@set emacsversion 24.5
+@set last-update February 2021
 @set rcsid $Id$
 
 @dircategory Theorem proving

--- a/proof-general-pkg.el
+++ b/proof-general-pkg.el
@@ -1,3 +1,3 @@
 (define-package "proof-general" "4.5-git"
   "A generic front-end for proof assistants (interactive theorem provers)"
-  '((emacs "24.3")))
+  '((emacs "24.5")))

--- a/proof-general.el
+++ b/proof-general.el
@@ -11,7 +11,7 @@
 
 ;; Authors: (see the AUTHORS file distributed along the sources)
 ;; URL: https://proofgeneral.github.io/
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "24.5"))
 ;; Version: 4.5-git
 
 ;; This software is free software; you can redistribute it and/or


### PR DESCRIPTION
This small PR is a follow-up of the discussion I had with @hendriktews last month.

To sum up:

* Although it is nice to support many emacs versions, and periodically add more versions within the PG CI configuration,
  it is also useful to drop support for very old emacsen at some point. Notably to be able to benefit from newest features :slightly_smiling_face:

* A possible policy that looked reasonable for @hendriktews and me is documented in the [`README.md` from this PR](https://github.com/ProofGeneral/PG/blob/3b93f2e1149ebd13e97d6fd4954269c07fe210bd/README.md#installing-proof-general).
  The MELPA/package.el metadata will naturally be updated as well by this PR.

* **Summary:** support Emacsen from the versions packaged in **Debian Stable** and **Ubuntu LTS until EoS**; which implies to:
  * Skip support for Emacs 24.3, 24.4 just now;
  * Skip support for Emacs 24.5 in May 2021 (given it is only packaged in Ubuntu 16.04 LTS, supported [until](https://wiki.ubuntu.com/Releases) April 2021)

Are you OK with this? Cc @ProofGeneral/core ; hopefully I could merge this PR by this Friday if you approve this.