### PR TITLE
Fix #563. Refactor search blacklist custom to avoid dual-send bug.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -142,6 +142,15 @@ and the PG Trac http://proofgeneral.inf.ed.ac.uk/trac
     file contains "Require ... ssreflect" on the same line; otherwise
     PG inserts "intros ..." as before.
 
+*** Customizing Search Blacklist (command created and menu entry moved)
+    To change the list of blacklisted string for Search commands
+    during development, use now
+    coq-change-search-blacklist-interactive. The menu for this has
+    moved, it is now in Coq/Other Queries/Search Blacklist.
+
+    To change the default blacklist, set variable
+    coq-search-blacklist-string (unchanged).
+
 *** bug fixes
     - avoid leaving partial files behind when compilation fails
     - 123: Parallel background compliation fails to execute some

--- a/coq/coq-abbrev.el
+++ b/coq/coq-abbrev.el
@@ -320,6 +320,7 @@
      ["Search..." coq-Search t]
      ["SearchRewrite..." coq-SearchRewrite t]
      ["SearchPattern..." coq-SearchIsos t]
+     ["Search Blacklist..." coq-change-search-blacklist-interactive t]
      ["Locate constant..." coq-LocateConstant t]
      ["Locate Library..." coq-LocateLibrary t]
      ["Pwd" coq-Pwd t]


### PR DESCRIPTION
Fix #563

Splitting the coq into two commands made me remove
coq-search-blacklist-string from defpgcustom. The visible effect is
that the menu entry has moved, and the command name changed. This is
explained in the CHANGES.