### PR TITLE
coq-par-compile: use doubly graph to unlock ancestors efficiently

### DIFF
--- a/ci/compile-tests/001-mini-project/runtest.el
+++ b/ci/compile-tests/001-mini-project/runtest.el
@@ -36,6 +36,7 @@
 (ert-deftest cct-mini-project ()
   "Test successful background compilation and ancestor recording."
   (find-file "a.v")
+  ; (setq coq--debug-auto-compilation t)
   (cct-process-to-line 25)
   
   (cct-check-locked 24 'locked)

--- a/ci/compile-tests/009-failure-processing/Makefile
+++ b/ci/compile-tests/009-failure-processing/Makefile
@@ -1,0 +1,44 @@
+# This file is part of Proof General.
+# 
+# © Copyright 2021  Hendrik Tews
+# 
+# Authors: Hendrik Tews
+# Maintainer: Hendrik Tews <hendrik@askra.de>
+# 
+# License:     GPL (GNU GENERAL PUBLIC LICENSE)
+
+
+# This test modifies some .v files during the test. The original
+# versions are in .v.orig files. They are moved to the corresponding
+# .v files before the test starts.
+TEST_SOURCES:=\
+	a1.v b1.v c1.v d1.v e1.v f1.v g1.v h1.v \
+	a2.v b2.v c2.v d2.v e2.v f2.v g2.v h2.v \
+	a3.v b3.v c3.v d3.v e3.v f3.v g3.v h3.v \
+	a4.v b4.v c4.v d4.v e4.v f4.v g4.v h4.v \
+	a5.v b5.v c5.v d5.v e5.v f5.v g5.v h5.v \
+	a6.v b6.v c6.v d6.v e6.v f6.v g6.v h6.v \
+	a7.v b7.v c7.v d7.v e7.v f7.v g7.v h7.v \
+	a8.v b8.v c8.v d8.v e8.v f8.v g8.v h8.v \
+	a9.v b9.v c9.v d9.v e9.v f9.v g9.v h9.v \
+	a10.v b10.v c10.v d10.v e10.v f10.v g10.v h10.v
+
+# This test uses ../bin/compile-test-start-delayed to start certain
+# commands with specified delays to check carfully constructed
+# internal states. compile-test-start-delayed outputs diagnostics on
+# file descriptor 9, which bypasses emacs and is joined with stderr of
+# the current make. Open file descriptor 9 here.
+.PHONY: test
+test:
+	$(MAKE) clean
+	$(MAKE) $(TEST_SOURCES)
+	emacs -batch -l ../../../generic/proof-site.el -l ../cct-lib.el \
+		-l runtest.el -f ert-run-tests-batch-and-exit \
+		9>&1
+
+%.v: %.v.orig
+	cp $< $@
+
+.PHONY: clean
+clean:
+	rm -f *.vo *.glob *.vio *.vos *.vok .*.aux *.X $(TEST_SOURCES)

--- a/ci/compile-tests/009-failure-processing/a1.v.orig
+++ b/ci/compile-tests/009-failure-processing/a1.v.orig
@@ -1,0 +1,28 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See runtest.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT/DELETE ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* The delay for coqdep is specified in comments with key coqdep-delay,
+ * see compile-test-start-delayed.
+ *)
+
+
+(* This is line 24 *)
+Require Export b1.
+Require Export c1.
+Require Export d1.
+(* This is line 28 *)

--- a/ci/compile-tests/009-failure-processing/a10.v.orig
+++ b/ci/compile-tests/009-failure-processing/a10.v.orig
@@ -1,0 +1,28 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See runtest.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT/DELETE ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* The delay for coqdep is specified in comments with key coqdep-delay,
+ * see compile-test-start-delayed.
+ *)
+
+
+(* This is line 24 *)
+Require Export b10.
+Require Export c10.
+Require Export d10.
+(* This is line 28 *)

--- a/ci/compile-tests/009-failure-processing/a2.v.orig
+++ b/ci/compile-tests/009-failure-processing/a2.v.orig
@@ -1,0 +1,28 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See runtest.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT/DELETE ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* The delay for coqdep is specified in comments with key coqdep-delay,
+ * see compile-test-start-delayed.
+ *)
+
+
+(* This is line 24 *)
+Require Export b2.
+Require Export c2.
+Require Export d2.
+(* This is line 28 *)

--- a/ci/compile-tests/009-failure-processing/a3.v.orig
+++ b/ci/compile-tests/009-failure-processing/a3.v.orig
@@ -1,0 +1,28 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See runtest.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT/DELETE ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* The delay for coqdep is specified in comments with key coqdep-delay,
+ * see compile-test-start-delayed.
+ *)
+
+
+(* This is line 24 *)
+Require Export b3.
+Require Export c3.
+Require Export d3.
+(* This is line 28 *)

--- a/ci/compile-tests/009-failure-processing/a4.v.orig
+++ b/ci/compile-tests/009-failure-processing/a4.v.orig
@@ -1,0 +1,28 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See runtest.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT/DELETE ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* The delay for coqdep is specified in comments with key coqdep-delay,
+ * see compile-test-start-delayed.
+ *)
+
+
+(* This is line 24 *)
+Require Export b4.
+Require Export c4.
+Require Export d4.
+(* This is line 28 *)

--- a/ci/compile-tests/009-failure-processing/a5.v.orig
+++ b/ci/compile-tests/009-failure-processing/a5.v.orig
@@ -1,0 +1,28 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See runtest.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT/DELETE ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* The delay for coqdep is specified in comments with key coqdep-delay,
+ * see compile-test-start-delayed.
+ *)
+
+
+(* This is line 24 *)
+Require Export b5.
+Require Export c5.
+Require Export d5.
+(* This is line 28 *)

--- a/ci/compile-tests/009-failure-processing/a6.v.orig
+++ b/ci/compile-tests/009-failure-processing/a6.v.orig
@@ -1,0 +1,28 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See runtest.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT/DELETE ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* The delay for coqdep is specified in comments with key coqdep-delay,
+ * see compile-test-start-delayed.
+ *)
+
+
+(* This is line 24 *)
+Require Export b6.
+Require Export c6.
+Require Export d6.
+(* This is line 28 *)

--- a/ci/compile-tests/009-failure-processing/a7.v.orig
+++ b/ci/compile-tests/009-failure-processing/a7.v.orig
@@ -1,0 +1,28 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See runtest.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT/DELETE ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* The delay for coqdep is specified in comments with key coqdep-delay,
+ * see compile-test-start-delayed.
+ *)
+
+
+(* This is line 24 *)
+Require Export b7.
+Require Export c7.
+Require Export d7.
+(* This is line 28 *)

--- a/ci/compile-tests/009-failure-processing/a8.v.orig
+++ b/ci/compile-tests/009-failure-processing/a8.v.orig
@@ -1,0 +1,28 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See runtest.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT/DELETE ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* The delay for coqdep is specified in comments with key coqdep-delay,
+ * see compile-test-start-delayed.
+ *)
+
+
+(* This is line 24 *)
+Require Export b8.
+Require Export c8.
+Require Export d8.
+(* This is line 28 *)

--- a/ci/compile-tests/009-failure-processing/a9.v.orig
+++ b/ci/compile-tests/009-failure-processing/a9.v.orig
@@ -1,0 +1,28 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See runtest.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT/DELETE ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* The delay for coqdep is specified in comments with key coqdep-delay,
+ * see compile-test-start-delayed.
+ *)
+
+
+(* This is line 24 *)
+Require Export b9.
+Require Export c9.
+Require Export d9.
+(* This is line 28 *)

--- a/ci/compile-tests/009-failure-processing/b1.v.orig
+++ b/ci/compile-tests/009-failure-processing/b1.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export f1.

--- a/ci/compile-tests/009-failure-processing/b10.v.orig
+++ b/ci/compile-tests/009-failure-processing/b10.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 1.5
+ *)
+
+Require Export f10.

--- a/ci/compile-tests/009-failure-processing/b2.v.orig
+++ b/ci/compile-tests/009-failure-processing/b2.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 2
+ *)
+
+Require Export f2.

--- a/ci/compile-tests/009-failure-processing/b3.v.orig
+++ b/ci/compile-tests/009-failure-processing/b3.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 3
+ *)
+
+Require Export f3.

--- a/ci/compile-tests/009-failure-processing/b4.v.orig
+++ b/ci/compile-tests/009-failure-processing/b4.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export f4.

--- a/ci/compile-tests/009-failure-processing/b5.v.orig
+++ b/ci/compile-tests/009-failure-processing/b5.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 1.5
+ *)
+
+Require Export f5.

--- a/ci/compile-tests/009-failure-processing/b6.v.orig
+++ b/ci/compile-tests/009-failure-processing/b6.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export f6.

--- a/ci/compile-tests/009-failure-processing/b7.v.orig
+++ b/ci/compile-tests/009-failure-processing/b7.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 1
+ *)
+
+Require Export f7.

--- a/ci/compile-tests/009-failure-processing/b8.v.orig
+++ b/ci/compile-tests/009-failure-processing/b8.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 1.5
+ *)
+
+Require Export f8.

--- a/ci/compile-tests/009-failure-processing/b9.v.orig
+++ b/ci/compile-tests/009-failure-processing/b9.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export f9.

--- a/ci/compile-tests/009-failure-processing/c1.v.orig
+++ b/ci/compile-tests/009-failure-processing/c1.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay X
+ *)
+
+Require Export e1 g1.

--- a/ci/compile-tests/009-failure-processing/c10.v.orig
+++ b/ci/compile-tests/009-failure-processing/c10.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay X
+ *)
+
+Require Export e10 g10.

--- a/ci/compile-tests/009-failure-processing/c2.v.orig
+++ b/ci/compile-tests/009-failure-processing/c2.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay X
+ *)
+
+Require Export e2 g2.

--- a/ci/compile-tests/009-failure-processing/c3.v.orig
+++ b/ci/compile-tests/009-failure-processing/c3.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay X
+ *)
+
+Require Export e3 g3.

--- a/ci/compile-tests/009-failure-processing/c4.v.orig
+++ b/ci/compile-tests/009-failure-processing/c4.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay X
+ *)
+
+Require Export e4 g4.

--- a/ci/compile-tests/009-failure-processing/c5.v.orig
+++ b/ci/compile-tests/009-failure-processing/c5.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay X
+ *)
+
+Require Export e5 g5.

--- a/ci/compile-tests/009-failure-processing/c6.v.orig
+++ b/ci/compile-tests/009-failure-processing/c6.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay X
+ *)
+
+Require Export e6 g6.

--- a/ci/compile-tests/009-failure-processing/c7.v.orig
+++ b/ci/compile-tests/009-failure-processing/c7.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay X
+ *)
+
+Require Export e7 g7.

--- a/ci/compile-tests/009-failure-processing/c8.v.orig
+++ b/ci/compile-tests/009-failure-processing/c8.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay X
+ *)
+
+Require Export e8 g8.

--- a/ci/compile-tests/009-failure-processing/c9.v.orig
+++ b/ci/compile-tests/009-failure-processing/c9.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay X
+ *)
+
+Require Export e9 g9.

--- a/ci/compile-tests/009-failure-processing/d1.v.orig
+++ b/ci/compile-tests/009-failure-processing/d1.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 1.5
+ *)
+
+Require Export h1.

--- a/ci/compile-tests/009-failure-processing/d10.v.orig
+++ b/ci/compile-tests/009-failure-processing/d10.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export h10.

--- a/ci/compile-tests/009-failure-processing/d2.v.orig
+++ b/ci/compile-tests/009-failure-processing/d2.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 3
+ *)
+
+Require Export h2.

--- a/ci/compile-tests/009-failure-processing/d3.v.orig
+++ b/ci/compile-tests/009-failure-processing/d3.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 2
+ *)
+
+Require Export h3.

--- a/ci/compile-tests/009-failure-processing/d4.v.orig
+++ b/ci/compile-tests/009-failure-processing/d4.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export h4.

--- a/ci/compile-tests/009-failure-processing/d5.v.orig
+++ b/ci/compile-tests/009-failure-processing/d5.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export h5.

--- a/ci/compile-tests/009-failure-processing/d6.v.orig
+++ b/ci/compile-tests/009-failure-processing/d6.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 1.5
+ *)
+
+Require Export h6.

--- a/ci/compile-tests/009-failure-processing/d7.v.orig
+++ b/ci/compile-tests/009-failure-processing/d7.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 1.5
+ *)
+
+Require Export h7.

--- a/ci/compile-tests/009-failure-processing/d8.v.orig
+++ b/ci/compile-tests/009-failure-processing/d8.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 1
+ *)
+
+Require Export h8.

--- a/ci/compile-tests/009-failure-processing/d9.v.orig
+++ b/ci/compile-tests/009-failure-processing/d9.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export h9.

--- a/ci/compile-tests/009-failure-processing/e1.v.orig
+++ b/ci/compile-tests/009-failure-processing/e1.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export b1.

--- a/ci/compile-tests/009-failure-processing/e10.v.orig
+++ b/ci/compile-tests/009-failure-processing/e10.v.orig
@@ -1,0 +1,25 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+(* Require Export b10. *)
+Definition e : nat := 3.

--- a/ci/compile-tests/009-failure-processing/e2.v.orig
+++ b/ci/compile-tests/009-failure-processing/e2.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export b2.

--- a/ci/compile-tests/009-failure-processing/e3.v.orig
+++ b/ci/compile-tests/009-failure-processing/e3.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export b3.

--- a/ci/compile-tests/009-failure-processing/e4.v.orig
+++ b/ci/compile-tests/009-failure-processing/e4.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export b4.

--- a/ci/compile-tests/009-failure-processing/e5.v.orig
+++ b/ci/compile-tests/009-failure-processing/e5.v.orig
@@ -1,0 +1,25 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+(* Require Export b5. *)
+Definition e : nat := 3.

--- a/ci/compile-tests/009-failure-processing/e6.v.orig
+++ b/ci/compile-tests/009-failure-processing/e6.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export b6.

--- a/ci/compile-tests/009-failure-processing/e7.v.orig
+++ b/ci/compile-tests/009-failure-processing/e7.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export b7.

--- a/ci/compile-tests/009-failure-processing/e8.v.orig
+++ b/ci/compile-tests/009-failure-processing/e8.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export b8.

--- a/ci/compile-tests/009-failure-processing/e9.v.orig
+++ b/ci/compile-tests/009-failure-processing/e9.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Require Export b9.

--- a/ci/compile-tests/009-failure-processing/f1.v.orig
+++ b/ci/compile-tests/009-failure-processing/f1.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition f : nat := 1.

--- a/ci/compile-tests/009-failure-processing/f10.v.orig
+++ b/ci/compile-tests/009-failure-processing/f10.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition f : nat := 1.

--- a/ci/compile-tests/009-failure-processing/f2.v.orig
+++ b/ci/compile-tests/009-failure-processing/f2.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition f : nat := 1.

--- a/ci/compile-tests/009-failure-processing/f3.v.orig
+++ b/ci/compile-tests/009-failure-processing/f3.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition f : nat := 1.

--- a/ci/compile-tests/009-failure-processing/f4.v.orig
+++ b/ci/compile-tests/009-failure-processing/f4.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition f : nat := 1.

--- a/ci/compile-tests/009-failure-processing/f5.v.orig
+++ b/ci/compile-tests/009-failure-processing/f5.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition f : nat := 1.

--- a/ci/compile-tests/009-failure-processing/f6.v.orig
+++ b/ci/compile-tests/009-failure-processing/f6.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition f : nat := 1.

--- a/ci/compile-tests/009-failure-processing/f7.v.orig
+++ b/ci/compile-tests/009-failure-processing/f7.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition f : nat := 1.

--- a/ci/compile-tests/009-failure-processing/f8.v.orig
+++ b/ci/compile-tests/009-failure-processing/f8.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition f : nat := 1.

--- a/ci/compile-tests/009-failure-processing/f9.v.orig
+++ b/ci/compile-tests/009-failure-processing/f9.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition f : nat := 1.

--- a/ci/compile-tests/009-failure-processing/g1.v.orig
+++ b/ci/compile-tests/009-failure-processing/g1.v.orig
@@ -1,0 +1,25 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 1
+ * coqc-delay X
+ *)
+
+(* coqdep error *)
+Require Export f1 h1

--- a/ci/compile-tests/009-failure-processing/g10.v.orig
+++ b/ci/compile-tests/009-failure-processing/g10.v.orig
@@ -1,0 +1,28 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 1
+ * coqc-delay 0
+ *)
+
+
+Require Export f10 h10.
+
+(* coqc error *)
+XXX.

--- a/ci/compile-tests/009-failure-processing/g2.v.orig
+++ b/ci/compile-tests/009-failure-processing/g2.v.orig
@@ -1,0 +1,25 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 1
+ * coqc-delay X
+ *)
+
+(* coqdep error *)
+Require Export f2 h2

--- a/ci/compile-tests/009-failure-processing/g3.v.orig
+++ b/ci/compile-tests/009-failure-processing/g3.v.orig
@@ -1,0 +1,25 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 1
+ * coqc-delay X
+ *)
+
+(* coqdep error *)
+Require Export f3 h3

--- a/ci/compile-tests/009-failure-processing/g4.v.orig
+++ b/ci/compile-tests/009-failure-processing/g4.v.orig
@@ -1,0 +1,25 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 1
+ * coqc-delay X
+ *)
+
+(* coqdep error *)
+Require Export f4 h4

--- a/ci/compile-tests/009-failure-processing/g5.v.orig
+++ b/ci/compile-tests/009-failure-processing/g5.v.orig
@@ -1,0 +1,25 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 1
+ * coqc-delay X
+ *)
+
+(* coqdep error *)
+Require Export f5 h5

--- a/ci/compile-tests/009-failure-processing/g6.v.orig
+++ b/ci/compile-tests/009-failure-processing/g6.v.orig
@@ -1,0 +1,28 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 1
+ *)
+
+
+Require Export f6 h6.
+
+(* coqc error *)
+XXX.

--- a/ci/compile-tests/009-failure-processing/g7.v.orig
+++ b/ci/compile-tests/009-failure-processing/g7.v.orig
@@ -1,0 +1,28 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+
+Require Export f7 h7.
+
+(* coqc error *)
+XXX.

--- a/ci/compile-tests/009-failure-processing/g8.v.orig
+++ b/ci/compile-tests/009-failure-processing/g8.v.orig
@@ -1,0 +1,28 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+
+Require Export f8 h8.
+
+(* coqc error *)
+XXX.

--- a/ci/compile-tests/009-failure-processing/g9.v.orig
+++ b/ci/compile-tests/009-failure-processing/g9.v.orig
@@ -1,0 +1,28 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 1
+ *)
+
+
+Require Export f9 h9.
+
+(* coqc error *)
+XXX.

--- a/ci/compile-tests/009-failure-processing/h1.v.orig
+++ b/ci/compile-tests/009-failure-processing/h1.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition h : nat := 2.

--- a/ci/compile-tests/009-failure-processing/h10.v.orig
+++ b/ci/compile-tests/009-failure-processing/h10.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition h : nat := 2.

--- a/ci/compile-tests/009-failure-processing/h2.v.orig
+++ b/ci/compile-tests/009-failure-processing/h2.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition h : nat := 2.

--- a/ci/compile-tests/009-failure-processing/h3.v.orig
+++ b/ci/compile-tests/009-failure-processing/h3.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition h : nat := 2.

--- a/ci/compile-tests/009-failure-processing/h4.v.orig
+++ b/ci/compile-tests/009-failure-processing/h4.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition h : nat := 2.

--- a/ci/compile-tests/009-failure-processing/h5.v.orig
+++ b/ci/compile-tests/009-failure-processing/h5.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition h : nat := 2.

--- a/ci/compile-tests/009-failure-processing/h6.v.orig
+++ b/ci/compile-tests/009-failure-processing/h6.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition h : nat := 2.

--- a/ci/compile-tests/009-failure-processing/h7.v.orig
+++ b/ci/compile-tests/009-failure-processing/h7.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition h : nat := 2.

--- a/ci/compile-tests/009-failure-processing/h8.v.orig
+++ b/ci/compile-tests/009-failure-processing/h8.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition h : nat := 2.

--- a/ci/compile-tests/009-failure-processing/h9.v.orig
+++ b/ci/compile-tests/009-failure-processing/h9.v.orig
@@ -1,0 +1,24 @@
+(* This file is part of Proof General.
+ *
+ * © Copyright 2021  Hendrik Tews
+ *
+ * Authors: Hendrik Tews
+ * Maintainer: Hendrik Tews <hendrik@askra.de>
+ *
+ * License:     GPL (GNU GENERAL PUBLIC LICENSE)
+ *
+ *
+ * This file is part of an automatic test case for parallel background
+ * compilation in coq-par-compile.el. See test.el in this directory.
+ *)
+
+(* The test script relies on absolute line numbers. 
+ * DO NOT INSERT ANY LINE UNLESS YOU KNOW WHAT YOU ARE DOING.
+ *)
+
+(* Specify delays for coqdep and coqc when processing this file:
+ * coqdep-delay 0
+ * coqc-delay 0
+ *)
+
+Definition h : nat := 2.

--- a/ci/compile-tests/009-failure-processing/runtest.el
+++ b/ci/compile-tests/009-failure-processing/runtest.el
@@ -1,0 +1,142 @@
+;; This file is part of Proof General.
+;;
+;; © Copyright 2021  Hendrik Tews
+;;
+;; Authors: Hendrik Tews
+;; Maintainer: Hendrik Tews <hendrik@askra.de>
+;;
+;; License:     GPL (GNU GENERAL PUBLIC LICENSE)
+
+;;; Commentary:
+;;
+;; Coq Compile Tests (cct) --
+;; ert tests for parallel background compilation for Coq
+;;
+;; Test a partially successful and partially failing compilation with
+;; coq-compile-keep-going. Check that the right files are compiled,
+;; locked and unlocked. Check also the case, where unlocking of failed
+;; files must be delayed, because some earlier successful require job
+;; has not yet locked its ancestors.
+;;
+;; The dependencies in this test are:
+;;
+;;    Rb    Rc  Rd
+;;    |     |   |
+;;    |     c   |
+;;    |    /|   |
+;;    |   / |   |
+;;    |  e  |   d
+;;    | ?   |   |
+;;    |?    |   |
+;;    b     g   /
+;;    |   _/|  /
+;;    | _/  | /
+;;    |/    |/
+;;    f     h
+;;
+;; Rb, Rc and Rd are three different require commands in file a. The
+;; dependency e -> b is not present in test 5 and test 10 (but in all
+;; other tests). The error always happens in file g, for test 1-5 with
+;; coqdep, for tests 6-10 with coqc. There are 10 tests, each with
+;; slighly different delays, in 10 versions of the sources, e.g.,
+;; a1-a10, b1-b10, and so on.
+;;
+;; For tests 1-5 coqdep fails on g, when this happens
+;;
+;; 1: Rb is ready and d still busy
+;; 2: f is ready and b and d are still busy and d finishes last
+;; 3: f is ready and b and d are still busy and b finishes last
+;; 4: RB is ready and Rd is queue waiting
+;; 5: without dependency e -> b: Rc, Rd are queue waiting, b finishes last
+;;
+;;
+;; For tests 6-10 coqc fails on g, when this happens
+;;
+;; 6: Rb is ready and d still busy
+;; 7: f is ready and b and d are still busy and d finishes last
+;; 8: f is ready and b and d are still busy and b finishes last
+;; 9: RB is ready and Rd is queue waiting
+;; 10: without dependency b -> e: Rc, Rd are queue waiting, b finishes last
+
+
+
+;; require cct-lib for the elisp compilation, otherwise this is present already
+(require 'cct-lib)
+
+;;; set configuration
+(cct-configure-proof-general)
+(configure-delayed-coq)    
+
+(defconst pre-b-ancestors '("b" "f")
+    "Ancestors of b without suffixes.")
+
+(defconst pre-all-compiled (append pre-b-ancestors '("e" "h" "d"))
+  "All files that get compiled.")
+
+(defun pre-not-compiled (n)
+  "List of file name stems for which coqc must not be called.
+Files for which coqc must not be called have an ``X'' in
+coqc-delay. For such files `compile-test-start-delayed' would
+create a ``.X'' file, whose absense is checked in the test."
+  (cond
+   ((< n 6) '("g" "c"))
+   (t       '("c"))))
+
+(defconst pre-all-unlocked '("c" "d" "e" "g" "h")
+  "All stems of files that should be unlocked after compilation.")
+
+(defun b-ancestors (n)
+  "Ancestors of b for part N."
+  (mapcar (lambda (f) (format "./%s%d.v" f n)) pre-b-ancestors))
+
+(defun all-compiled (n)
+  "All files that get compiled for part N."
+  (mapcar (lambda (f) (format "./%s%d.v" f n)) pre-all-compiled))
+
+(defun all-compiled-vo (n)
+  "All vo files for part N."
+  (mapcar 'cct-library-vo-of-v-file (all-compiled n)))
+
+(defun not-compiled (n)
+  "Files that should not be compiled for part N, see `pre-not-compiled'."
+  (mapcar (lambda (f) (format "./%s%d.v.X" f n)) (pre-not-compiled n)))
+
+(defun all-unlocked (n)
+  "All files that should be unlocked after compilation for part N."
+  (mapcar (lambda (f) (format "./%s%d.v" f n)) pre-all-unlocked))
+
+
+;;; Define the test
+
+(defun test-failure-processing (n)
+  "Test partially successful and partially failing compilation, part N."
+  ;; (setq cct--debug-tests t)
+  ;; (setq coq--debug-auto-compilation t)
+  (find-file (format "a%d.v" n))
+  (message "coqdep: %s\ncoqc: %s\nPATH %s\nexec-path: %s"
+           coq-dependency-analyzer
+           coq-compiler
+           (getenv "PATH")
+           exec-path)
+
+  (message "\n%d. Partially failing compilation part %d\n" n n)
+  (cct-process-to-line 28)
+  (cct-check-locked 25 'locked)
+  (cct-check-locked 26 'unlocked)
+  (cct-locked-ancestors 25 (b-ancestors n))
+  (cct-check-files-locked 24 'locked (b-ancestors n))
+  (cct-check-files-locked 1 'unlocked (all-unlocked n))
+  (cct-files-are-readable (all-compiled-vo n))
+  (cct-files-dont-exist (not-compiled n)))
+
+
+(ert-deftest cct-failure-processing-01 () (test-failure-processing 1))
+(ert-deftest cct-failure-processing-02 () (test-failure-processing 2))
+(ert-deftest cct-failure-processing-03 () (test-failure-processing 3))
+(ert-deftest cct-failure-processing-04 () (test-failure-processing 4))
+(ert-deftest cct-failure-processing-05 () (test-failure-processing 5))
+(ert-deftest cct-failure-processing-06 () (test-failure-processing 6))
+(ert-deftest cct-failure-processing-07 () (test-failure-processing 7))
+(ert-deftest cct-failure-processing-08 () (test-failure-processing 8))
+(ert-deftest cct-failure-processing-09 () (test-failure-processing 9))
+(ert-deftest cct-failure-processing-10 () (test-failure-processing 10))

--- a/ci/compile-tests/README.md
+++ b/ci/compile-tests/README.md
@@ -32,10 +32,14 @@ All tests are for parallel background compilation.
 : test that the default/current directory is set correctly
   independent of user/emacs changing the current buffer during
   first and second stage compilation
+009-failure-processing
+: check ancestor unlocking for a failed job with
+  coq-compile-keep-going; test also the case, where the last
+  (failed) require job must be delayed, because some queue
+  dependee is still processing
 
 # Tests currently missing
 
-- unlock checks for ancestors of failed jobs in different cases
 - a job depending on a failed dependee, where the dependee has
   been finished before
 - coq-par-create-file-job detects a dependency cycle

--- a/ci/compile-tests/bin/compile-test-start-delayed
+++ b/ci/compile-tests/bin/compile-test-start-delayed
@@ -21,11 +21,17 @@ function usage(){
 	Start program prog with arguments args with some delay. There
 	must be at least one argument in args and the last one must be
 	a file or something that becomes a file when ".v" is appended.
-        The delay is taken from a line in that file that
+	The delay is taken from a line in that file that
 	contains the key, followed by a space and the delay in seconds
 	(maybe somewhere in the middle of the line). The file must
 	contain at most one line containing key. When there is no line
-	containing key the delay is zero.
+	containing key the delay is zero. As a special case, a delay
+	equal to X means to record the fact that prog has been called
+	on file by creating a file with suffix ".X" added to the name
+	of file. The absence of this .X file can then be used, for
+	instance, to check that prog has not been called on file. With
+	delay equal to X, the real delay is 0.
+        Fractional delays are properly handled.
 EOF
 }
 
@@ -53,21 +59,25 @@ if [ ! -f "$file" ] ; then
     fi
 fi
 
-delay=$(sed -ne "/$key/ s/.*$key \([0-9]*\).*/\1/p" $file)
+delay=$(sed -ne "/$key/ s/.*$key \([X0-9.]*\).*/\1/p" $file)
 
 if [ -z "$delay" ] ; then
     # echo compile-test-start-delayed: key $key not found in $file >&9
     delay=0
+elif [ "$delay" = "X" ] ; then
+    echo compile-test-start-delayed: delay X for $file >&9
+    delay=0
+    touch $file.X
 fi
 
-if [ $delay -ne 0 ] ; then
-    date "+compile-test-start-delayed +%Y-%m-%d %T %Z" >&9
-    echo delay $delay for $@ >&9
+# use string comparison on $delay to permit fractional values
+if [ $delay != 0 ] ; then
+    date "+compile-test-start-delayed %T delay $delay for $*" >&9
+    sleep $delay
+    date "+compile-test-start-delayed %T start now $*" >&9
+else
+    date "+compile-test-start-delayed %T start without delay $*" >&9
 fi
-
-sleep $delay
-date "+compile-test-start-delayed +%Y-%m-%d %T %Z" >&9
-echo start $@ >&9
 
 #set -x
 #echo "$@"

--- a/ci/compile-tests/cct-lib.el
+++ b/ci/compile-tests/cct-lib.el
@@ -214,6 +214,20 @@ region of the buffer and signals a test failure if not."
            (funcall (if locked '< '>)
                     (point) (span-end proof-locked-span)))))))
 
+(defun cct-check-files-locked (line lock-state files)
+  "Check that all FILES at line number LINE have lock state LOCK-STATE.
+LOCK-STATE must be either 'locked or 'unlocked. FILES must be
+list of file names."
+  (when cct--debug-tests
+    (message "check files %s at line %d: %s"
+             (if (eq lock-state 'locked) "locked" "unlocked") line files))
+  (save-current-buffer
+    (mapc
+     (lambda (file)
+       (find-file file)
+       (cct-check-locked line lock-state))
+     files)))
+
 (defun cct-locked-ancestors (line ancestors)
   "Check that the vanilla span at line LINE has ANCESTORS recorded.
 The comparison treats ANCESTORS as set but the file names must
@@ -296,6 +310,12 @@ or changed since recording the time in the association."
   (when cct--debug-tests
     (message "Files should exist and be readable: %s" files))
   (mapc (lambda (fname) (should (file-readable-p fname))) files))
+
+(defun cct-files-dont-exist (files)
+  "Check that FILES don't exist."
+  (when cct--debug-tests
+    (message "Files should not exist: %s" files))
+  (mapc (lambda (fname) (should-not (file-exists-p fname))) files))
 
 (defun cct-generic-check-main-buffer
     (main-buf main-unlocked main-locked main-sum-line new-sum


### PR DESCRIPTION
Change from a singly linked graph (only childs point to parents)
to a doubly linked graph (also parents point to childs). Instead
of propagating ancestors upwards as compilation progresses,
ancestors are now collected when require jobs are retired. This
makes it easier to avoid exponential blowup when traversing the
graph. Additionally, completely link ancestors that are ready
into the graph. Fixes #572.