### PR TITLE
Fix font-lock-variable-name-face when combining { or [ and ssreflect "colon tactics"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,15 @@ and the PG Trac http://proofgeneral.inf.ed.ac.uk/trac
 
 ** Coq changes
 
+*** fix highlighting issues for ssr tactics ending with colon
+
+    Now, { exact: term. } will always be correctly highlighted.
+
+    However, only (forall {T: Type}, Type) will be highlighted,
+    unlike term (forall { T: Type }, Type) that has a spurious space.
+
+    Also in (forall [T: Type], Type), variable T is now highlighted.
+
 *** new menu Coq -> Auto Compilation for all background compilation options
 
 *** support for 8.11 vos and vok compilation

--- a/coq/coq-syntax.el
+++ b/coq/coq-syntax.el
@@ -1300,6 +1300,10 @@ different."
 (defun coq-first-abstr-regexp (paren end)
   (concat paren "\\s-*\\(" coq-ids "\\)\\s-*" end))
 
+(defun coq-first-abstr-without-space-regexp (paren end)
+  "Variant of `coq-first-abstr-regexp' without space between PAREN & `coq-ids'."
+  (concat paren "\\(" coq-ids "\\)\\s-*" end))
+
 (defcustom coq-variable-highlight-enable t
   "Activates partial bound variable highlighting."
   :type 'boolean
@@ -1334,7 +1338,8 @@ different."
       ;;               (list 0 font-lock-variable-name-face)))
       ;; parenthesized binders
       (list (coq-first-abstr-regexp "(" ":[ a-zA-Z]") 1 'font-lock-variable-name-face)
-      (list (coq-first-abstr-regexp "{" ":[ a-zA-Z]") 1 'font-lock-variable-name-face)
+      ;; Don't use coq-first-abstr-regexp here, see ProofGeneral/PG#581:
+      (list (coq-first-abstr-without-space-regexp "{" ":[ a-zA-Z]") 1 'font-lock-variable-name-face)
       )))
   "*Font-lock table for Coq terms.")
 

--- a/coq/coq-syntax.el
+++ b/coq/coq-syntax.el
@@ -1340,6 +1340,8 @@ different."
       (list (coq-first-abstr-regexp "(" ":[ a-zA-Z]") 1 'font-lock-variable-name-face)
       ;; Don't use coq-first-abstr-regexp here, see ProofGeneral/PG#581:
       (list (coq-first-abstr-without-space-regexp "{" ":[ a-zA-Z]") 1 'font-lock-variable-name-face)
+      ;; Likewise, for https://coq.github.io/doc/V8.12.0/refman/language/extensions/implicit-arguments.html#implicit-argument-binders :
+      (list (coq-first-abstr-without-space-regexp "\\[" ":[ a-zA-Z]") 1 'font-lock-variable-name-face)
       )))
   "*Font-lock table for Coq terms.")
 


### PR DESCRIPTION
Close #581 

Demo screenshot:

![2021-06-03_18-01-36_Screenshot_PG_PR_issue_581](https://user-images.githubusercontent.com/10367254/120675970-da812500-c495-11eb-8821-190d43f9869f.png)

<details><summary>Source code</summary>

```coq
Require Import ssreflect.

Goal True /\ True.
split.
{ exact: I. }
exact: I.
Qed.

Goal True /\ True.
split; [ exact: I | exact: I ].
Qed.

Check forall {T1 : Type} [T2 : Type], Type.

(* we just won't have some highlighting if ever we write *)

Check forall { T1 : Type } [ T2 : Type ], Type.

(* And there's no such highlighting with font-lock-variable-name-face in records
   as it would be irrelevant for them, given projections are not variables *)

Require Import Floats.
Record cplx := { Re: float; Im: float }.
Check {| Re := 0%float ; Im := 0%float |}.
```

</details>