### PR TITLE
Handle single-quotes in arguments to `-arg`

### DIFF
--- a/coq/coq-system.el
+++ b/coq/coq-system.el
@@ -123,7 +123,6 @@ This function supports calling coqtop via tramp."
           (if (or (not expectedretv) (equal retv expectedretv))
               (buffer-string)))
       (error nil))))
-        
 
 (defun coq-autodetect-version (&optional interactive-p)
   "Detect and record the version of Coq currently in use.
@@ -554,16 +553,18 @@ Returns a mixed list of option-value pairs and strings."
 OPTIONS is a list or conses (switch . argument) and strings.
 Note that the semantics of the -arg flags in coq project files
 are weird: -arg \"a b\" means pass a and b, separately, to
-coqtop."
+coqtop. But -arg \"'a b'\" means to pass a and b together."
   (let ((args nil))
     (dolist (opt options)
       (pcase opt
         ((or "-byte" "-op")
          (push opt args))
         (`("-arg" ,concatenated-args)
-         (setq args
-               (append args
-                       (split-string-and-unquote concatenated-args coq--project-file-separator))))))
+	 (if (and (string-prefix-p "'" concatenated-args) (string-suffix-p "'" concatenated-args))
+	     (setq args (append args (list (substring concatenated-args 1 -1))))
+           (setq args
+		 (append args
+			 (split-string-and-unquote concatenated-args coq--project-file-separator)))))))
     (cons "-emacs" args)))
 
 (defun coq--extract-load-path-1 (option base-directory)


### PR DESCRIPTION
A haphazard sketch to issue #589. It is *not* an acceptable final solution, I think

coq_makefile parses _CoqProject files in a slightly weird way. If we write `-arg "a b"` in _CoqProject then it passes the arguments `a` and `b` to coqc, but if we write `-arg "'a b'"` it passes `a b` to coqc, as a single argument.

I tried to adapt PG to this behavior. It works for my use-case, but I haven’t tested where the differences in behaviour (between PG and coq_makefile) lie now. A weird fact is, that coq_makefile produces some string, which it stores in `Makefile.coq.conf`, which later gets processed by make and passed on to coqc. So a "good" solution would try to reproduce the complete processing chain, i.e. first the processing done by coq_makefile, then the processing done by make.

Maybe we could call [`lib/coqProject_file.mli`](https://github.com/coq/coq/blob/master/lib/coqProject_file.mli) from elisp and hand over the parsing to the OCaml code of the coq repo.