### PR TITLE
fix: parsing of `coqtop -v` for 8.14+rc1

### DIFF
--- a/coq/coq-system.el
+++ b/coq/coq-system.el
@@ -123,7 +123,6 @@ This function supports calling coqtop via tramp."
           (if (or (not expectedretv) (equal retv expectedretv))
               (buffer-string)))
       (error nil))))
-        
 
 (defun coq-autodetect-version (&optional interactive-p)
   "Detect and record the version of Coq currently in use.
@@ -131,7 +130,7 @@ Interactively (with INTERACTIVE-P), show that number."
   (interactive '(t))
   (setq coq-autodetected-version nil)
   (let* ((str (coq-callcoq "-v" 0))
-         (mtch (and str (string-match "version \\([^ ]+\\)" str))))
+         (mtch (and str (string-match "version \\([^ \n]+\\)" str))))
     (when mtch
       (setq coq-autodetected-version (match-string 1 str))))
   (when interactive-p (coq-show-version))


### PR DESCRIPTION
Close #600 

Note: the function `(coq--version<)` already supported `_+rcN` suffixes.

So the compatibility issue was just coming from the fact `coqtop -v`
changed its output format; namely:

The Coq Proof Assistant, version 8.13.2 (September 2021)
compiled on Sep 12 2021 11:24:20 with OCaml 4.07.1

The Coq Proof Assistant, version 8.14+rc1
compiled with OCaml 4.12.0