### PR TITLE
fix(generic/pg-user.el): Auto-indent within `C-c C-n`

### DIFF
--- a/generic/pg-user.el
+++ b/generic/pg-user.el
@@ -192,6 +192,9 @@ If inside a comment, just process until the start of the comment."
    (save-excursion
      (goto-char (proof-queue-or-locked-end))
      (skip-chars-forward " \t\n")
+     (if (eq proof-assistant-symbol 'coq)
+         (smie-indent-line)
+       (proof-indent-line))
      (proof-assert-until-point))
    (proof-maybe-follow-locked-end)))
 


### PR DESCRIPTION
* (proof-assert-next-command-interactive): Call (proof-indent-line) by
  default or (smie-indent-line) if the current proof-assistant is coq.

Close #603