### PR TITLE
* generic/proof-script.el: Don't retract on indent (#604)

### DIFF
--- a/coq/coq.el
+++ b/coq/coq.el
@@ -2732,10 +2732,8 @@ insertion point for the \"using\" annotation. ")
 
 (defun coq-insert-proof-using (_proof-pos _previous-content insert-point string-suggested)
   (goto-char insert-point)
-  (let ((spl proof-locked-span))
-    (span-read-write spl) ; temporarily make the locked span writable
-    (insert (concat " using " string-suggested))
-    (proof-span-read-only spl)))
+  (let ((proof--inhibit-retract-on-change t))
+    (insert (concat " using " string-suggested))))
 
 (defun coq-insert-suggested-dependency ()
   (interactive)

--- a/generic/pg-pbrpm.el
+++ b/generic/pg-pbrpm.el
@@ -1,4 +1,4 @@
-;; pg-pbrpm.el --- Proof General - Proof By Rules Pop-up Menu - mode.
+;; pg-pbrpm.el --- Proof General - Proof By Rules Pop-up Menu - mode.  -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (C) 2004 - Universite de Savoie, France.
 ;; Authors:   Jean-Roch SOTTY, Christophe Raffalli
@@ -98,12 +98,10 @@ Matches the region to be returned.")
 	    (mapc (lambda (sp)
 		    (let* ((p1 (span-start sp))
 			   (p2 (span-end sp))
-			   (spl (span-at p1 'pglock)))
-		      (span-read-write spl)
+			   (proof--inhibit-retract-on-change t))
 		      (goto-char p1)
 		      (insert (span-string span))
-		      (delete-region (+ p1 len) (+ p2 len))
-		      (span-read-only spl)))
+		      (delete-region (+ p1 len) (+ p2 len))))
 		  (span-property span 'occurrences)))))))
 
 
@@ -257,7 +255,8 @@ The prover command is processed via pg-pbrpm-run-command."
 		       (insert-gui-button (make-gui-button
 					   (concat (int-to-string count) ")")
 					   'pg-pbrpm-run-command
-					   (list command act spans)) pos))
+					   (list command act spans))
+					  pos))
 		     (insert "\n")))
 		 (insert-gui-button
 		  (make-gui-button

--- a/lib/span.el
+++ b/lib/span.el
@@ -3,7 +3,7 @@
 ;; This file is part of Proof General.
 
 ;; Portions © Copyright 1994-2012  David Aspinall and University of Edinburgh
-;; Portions © Copyright 2003-2018  Free Software Foundation, Inc.
+;; Portions © Copyright 2003-2021  Free Software Foundation, Inc.
 ;; Portions © Copyright 2001-2017  Pierre Courtieu
 ;; Portions © Copyright 2010, 2016  Erik Martin-Dorel
 ;; Portions © Copyright 2011-2013, 2016-2017  Hendrik Tews
@@ -50,11 +50,6 @@
   ;; (overlay-put span 'read-only t))
   (span-set-property span 'modification-hooks '(span-read-only-hook))
   (span-set-property span 'insert-in-front-hooks '(span-read-only-hook)))
-
-(defun span-read-write (span)
-  "Set SPAN to be writeable."
-  (span-set-property span 'modification-hooks nil)
-  (span-set-property span 'insert-in-front-hooks nil))
 
 (defun span-write-warning (span fun)
   "Give a warning message when SPAN is changed, unless `inhibit-read-only' is non-nil."


### PR DESCRIPTION
(proof--inhibit-retract-on-change): New var.
(proof-retract-before-change): Obey it.
(proof-config-done): Set it while indenting.