### PR TITLE
Fix #608. PG not auto adapting window width.

### DIFF
--- a/ci/coq-tests.el
+++ b/ci/coq-tests.el
@@ -133,7 +133,9 @@ then evaluate the BODY function and finally tear-down (exit Coq)."
 ;;; For info on macros: https://mullikine.github.io/posts/macro-tutorial
 ;;; (pp (macroexpand '(macro args)))
   (save-excursion
-    (let* ((openfile (or file
+    (let* (;; avoids bad width detection in batch mode 
+           (coq-auto-adapt-printing-width nil)
+           (openfile (or file
                          (concat (make-temp-file coq-test-file-prefix) ".v")))
            ;; if FILE is nil, create a temporary Coq file, removed in the end
            (rmfile (unless file openfile))


### PR DESCRIPTION
The option setting was flawed. A recent code cleaning by @monnier revealed it.
Now the hooks are set once and forall correctly and obey the setting.

- [ ] add tests