### PR TITLE
Fix #625 Indentation very slow.

### DIFF
--- a/ci/test-indent/indent-tac.v
+++ b/ci/test-indent/indent-tac.v
@@ -184,7 +184,7 @@ Module foo.
           simpl;
           intros...
         ]
-      ]
+      ].
   Qed.
 
 


### PR DESCRIPTION
Had to change the associativity from `left` to `assoc` for token
`"."`. This speeds up things by limiting smie token lookups.

I had to change a few indentation rules to restore the correct
behaviour with the new grammar. I had to:

- use `smie-indent-virtual`

And as side effects:

- fix a wrong tests.
- fix bugs in find-real-start with sequences of "{ subproof" and comments.

Left for another PR: cleaning up dead code in coq-indent.el.