### PR TITLE
Fix version number parsing on some confused Windows installations

### DIFF
--- a/coq/coq-system.el
+++ b/coq/coq-system.el
@@ -130,7 +130,7 @@ Interactively (with INTERACTIVE-P), show that number."
   (interactive '(t))
   (setq coq-autodetected-version nil)
   (let* ((str (coq-callcoq "-v" 0))
-         (mtch (and str (string-match "version \\([^ \n]+\\)" str))))
+         (mtch (and str (string-match "version \\([^ \r\n]+\\)" str))))
     (when mtch
       (setq coq-autodetected-version (match-string 1 str))))
   (when interactive-p (coq-show-version))


### PR DESCRIPTION
Reported by a student of @al3623

```
File mode specification error: (coq-unclassifiable-version . 8.15.0^M
compiled)
```

The workaround if the student can't update after this PR is merged would be `(setq coq-pinned-version "8.15.0")`