### PR TITLE
emacs 25 compatibility: don't use caddr or cadddr

### DIFF
--- a/coq/coq-smie.el
+++ b/coq/coq-smie.el
@@ -1285,7 +1285,7 @@ If nil, default to `proof-indent' if it exists or to `smie-indent-basic'."
   (let* ((beg (if (listp (car parent)) (caar parent) (car parent)))
          (end (cadr parent))
          (regi (list (list beg end)))
-         (tok (caddr parent))
+         (tok (car (cddr parent)))
          (face (cond
                 ((equal num 1) 'hlt-regexp-level-1)
                 ((equal num 2) 'hlt-regexp-level-2)
@@ -1306,7 +1306,7 @@ If nil, default to `proof-indent' if it exists or to `smie-indent-basic'."
    (let* ((beg (if (listp (car parent)) (caar parent) (car parent)))
           (end (cadr parent))
           (regi (list (list beg end)))
-          ;; (tok (caddr parent))
+          ;; (tok (car (cddr parent)))
           (face (cond
                  ((equal num 2) 'hlt-regexp-level-2)
                  (t 'hlt-regexp-level-1))))

--- a/coq/coq.el
+++ b/coq/coq.el
@@ -2761,7 +2761,7 @@ SPAN is the span of the whole theorem (statement + proof)."
         (when lproof-info
           (let* ((proof-pos (car lproof-info)) ;(proof-pos (match-beginning 0))
                  (insert-point (cadr lproof-info)) ;(insert-point (match-beginning 1))
-                 (proof-end (caddr lproof-info))
+                 (proof-end (cl-caddr lproof-info))
                  (previous-string (buffer-substring insert-point proof-end))
                  (previous-content (split-string previous-string))
                  (suggested (span-property span 'dependencies))

--- a/generic/proof-shell.el
+++ b/generic/proof-shell.el
@@ -1111,8 +1111,8 @@ Argument QUEUEITEM must be an action item as documented for
 `proof-action-list'. Add flag 'priority-action to QUEUEITEM, such
 that priority items can be recognized and the order of added
 priority items can be preserved."
-  (let ((qi (list (car queueitem) (cadr queueitem) (caddr queueitem)
-                  (cons 'priority-action (cadddr queueitem)))))
+  (let ((qi (list (car queueitem) (cadr queueitem) (cl-caddr queueitem)
+                  (cons 'priority-action (cl-cadddr queueitem)))))
     (push qi proof-priority-action-list)
     (proof-start-prover-with-priority-items-maybe)))
 


### PR DESCRIPTION
All the emacs 25 tests failed in PR #626 because of these functions after I rebased that PR to current master.