### PR TITLE
Do not offer to save (temporary) buffers without associated files

### DIFF
--- a/generic/proof-script.el
+++ b/generic/proof-script.el
@@ -2814,10 +2814,6 @@ finish setup which depends on specific proof assistant configuration."
   (proof-setup-imenu)
   (proof-imenu-enable)
 
-  ;; Save file-less script mode buffers in case of accidental exit
-  (or (buffer-file-name)
-      (setq buffer-offer-save t))
-
   ;; Turn on autosend if enabled
   (proof-autosend-enable 'nomsg)
 


### PR DESCRIPTION
This restores the default behaviour of Emacs. If a user wants to be more
careful about saving temporary buffers, they can set `buffer-offer-save` via
the appropriate hooks.

This commit effectively reverts b8cca128a40ee0d72bc627a5d320cdde12b3d87c

Closes #668