### PR TITLE
Fixed an error when `proof-ignore-for-undo-count` is a function.

### DIFF
--- a/generic/proof-script.el
+++ b/generic/proof-script.el
@@ -2736,7 +2736,7 @@ with something different."
 	      (eq typ 'proverproc)
 	      (eq typ 'proof)
 	      (and proof-ignore-for-undo-count cmd
-		   (proof-string-match proof-ignore-for-undo-count cmd))))
+		   (proof-stringfn-match proof-ignore-for-undo-count cmd))))
 	 ;; some named element: use generic forget-id function; finish.
 	 ((setq name (span-property span 'name))
 	  (setq ans (format proof-forget-id-command name))


### PR DESCRIPTION
As per `proof-ignore-for-undo-count`'s [declared type](https://github.com/ProofGeneral/PG/blob/bbbb1e2604996513cd05f54da1b8ef059a8e8968/generic/proof-config.el#L484-L490), it is possible for it to be a function.

This is a simple commit that fixes an error when you try using it as such.