### PR TITLE
Invalid function error on proof-unicode-tokens-toggle

### DIFF
--- a/generic/proof-unicode-tokens.el
+++ b/generic/proof-unicode-tokens.el
@@ -30,6 +30,7 @@
   ;; (require 'proof-auxmodes)	 ; loaded by proof.el, autoloads us
   (require 'unicode-tokens))	 ; it will be loaded by proof-auxmodes
 
+(eval-when-compile (require 'proof-utils))	; import macros
 (require 'proof-config)			; config variables
 
 (defvar proof-unicode-tokens-initialised nil


### PR DESCRIPTION
When running proof-unicode-tokens-toggle on proof-general-20221130.946, the following error was printed to *Messages*.

```
proof-unicode-tokens-configure: Invalid function: proof-ass-symv
```

This may be because proof-unicode-token.el does not load macros, so I applied this patch.
