### PR TITLE
ci/coq-tests: expect 060_coq-test-wholefile to pass for 8.18

### DIFF
--- a/ci/coq-tests.el
+++ b/ci/coq-tests.el
@@ -260,7 +260,7 @@ For example, COMMENT could be (*test-definition*)"
 
 (ert-deftest 060_coq-test-wholefile ()
   ;; test_wholefile.v triggers a fatal warning in 8.17, see also #698
-  :expected-result (if (coq--post-v817) :failed :passed)
+  :expected-result (if (coq--is-v817) :failed :passed)
   "Test `proof-process-buffer'."
   (coq-fixture-on-file
    (coq-test-full-path "test_wholefile.v")

--- a/coq/coq-system.el
+++ b/coq/coq-system.el
@@ -218,12 +218,13 @@ Return nil if the version cannot be detected."
 	 (signal 'coq-unclassifiable-version  coq-version-to-use))
 	(t (signal (car err) (cdr err))))))))
 
-(defun coq--post-v817 ()
-  "Return t if the auto-detected version of Coq is >= 8.17.
+(defun coq--is-v817 ()
+  "Return t if the auto-detected version of Coq is some 8.17 version.
 Return nil if the version cannot be detected."
   (let ((coq-version-to-use (or (coq-version t) "8.16")))
     (condition-case err
-	(not (coq--version< coq-version-to-use "8.17"))
+	(and  (not (coq--version< coq-version-to-use "8.17"))
+              (coq--version< coq-version-to-use "8.18alpha"))
       (error
        (cond
 	((equal (substring (cadr err) 0 15) "Invalid version")


### PR DESCRIPTION
Annotate test 060_coq-test-wholefile such that it is expected to pass for versions prior 8.17 and anything following after 8.17, i.e., it should pass on 8.18+rc1.