### PR TITLE
Fix "Bad bounding indices" error on invalid _CoqProject

### DIFF
--- a/coq/coq-system.el
+++ b/coq/coq-system.el
@@ -553,7 +553,7 @@ If ARITY is nil, return SWITCH."
   (cond
    ((not arity) switch)
    ((< (length raw-args) arity)
-    (warn "Invalid _CoqProject: not enough arguments for %S" switch)
+    (message "Invalid _CoqProject: not enough arguments for %S" switch)
     switch)
    (t
     (let ((arguments (cl-subseq raw-args 0 arity)))

--- a/coq/coq-system.el
+++ b/coq/coq-system.el
@@ -550,13 +550,14 @@ alreadyopen is t if buffer already existed."
 (defun coq--read-one-option-from-project-file (switch arity raw-args)
   "Cons SWITCH with ARITY arguments from RAW-ARGS.
 If ARITY is nil, return SWITCH."
-  (if arity
-      (let ((arguments
-             (condition-case-unless-debug nil
-                 (cl-subseq raw-args 0 arity)
-               (warn "Invalid _CoqProject: not enough arguments for %S" switch))))
-        (cons switch arguments))
-    switch))
+  (cond
+   ((not arity) switch)
+   ((< (length raw-args) arity)
+    (warn "Invalid _CoqProject: not enough arguments for %S" switch)
+    switch)
+   (t
+    (let ((arguments (cl-subseq raw-args 0 arity)))
+      (cons switch arguments)))))
 
 (defun coq--read-options-from-project-file (contents)
   "Read options from CONTENTS of _CoqProject.


### PR DESCRIPTION
Fixes #707.

The first commit is purely the bugfix. (Note: I didn't understand the previous code, as I am no Elisp expert, maybe it is doing something really important besides producing very obscure failure modes?)

The second commit turns `warn` into `message`. When testing with only the first commit I did not manage to see the `warn` string anywhere on my Emacs, so the error is a bit too silent to my taste. (We are noticing that the user _CoqProject is broken and just silently ignoring it.) `message` is slightly better. I wonder if `error` wouldn't be even better, but the current code logic is to be resilient and ignore the error, so I kept that.