### PR TITLE
[minor] silence an Emacs warning about above-80-chars docstring

### DIFF
--- a/generic/proof-site.el
+++ b/generic/proof-site.el
@@ -241,8 +241,8 @@ Note: to change proof assistant, you must start a new Emacs session.")
       proof-assistants
       (mapcar #'car proof-assistant-table))
   "A list of the configured proof assistants.
-Set on startup to contents of environment variable PROOFGENERAL_ASSISTANTS,
-the Lisp variable `proof-assistants', or the contents of `proof-assistant-table'.")
+Set on startup to contents of environment variable PROOFGENERAL_ASSISTANTS, the
+Lisp variable `proof-assistants', or the contents of `proof-assistant-table'.")
 
 ;; Add auto-loads and load-path elements to support the
 ;; proof assistants selected, and define stub major mode functions


### PR DESCRIPTION
> ⛔ Warning (comp): proof-site.el:249:2: Warning: defvar `proof-general-configured-provers' docstring wider than 80 characters