### PR TITLE
coq/coq-mode.el: Change the definition of 'coq--parent-mode

### DIFF
--- a/coq/coq-mode.el
+++ b/coq/coq-mode.el
@@ -179,8 +179,8 @@ Near here means PT is either inside or just aside of a comment."
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.v\\'" . coq-mode))
 
-(defun coq--parent-mode ()
-  (if coq-use-pg (proof-mode) (prog-mode)))
+(defalias 'coq--parent-mode
+  (if coq-use-pg 'proof-mode 'prog-mode))
 
 ;;;###autoload
 (define-derived-mode coq-mode coq--parent-mode "Coq"


### PR DESCRIPTION
## Problem Description

The current definition of 'coq--parent-mode is as follows:

```elisp
(defun coq--parent-mode ()
  (if coq-use-pg (proof-mode) (prog-mode)))
```

It currently functions correctly. However, this definition breaks the major mode hierarchy. For example:

```elisp
(get 'coq-mode 'derived-mode-parent)
; => 'coq--parent-mode
``` 

And the built-in Emacs function, `derived-mode-p`, also cannot recognize that `coq-mode` is a sub-mode of `prog-mode`:

```elisp
;; when you are in coq buffer
(derived-mode-p 'prog-mode)
; => nil
```

Some Emacs code, such as Spacemacs, relies on this information to determine if a buffer is a text/program file. For example, Spacemacs will display line numbers for all sub-modes of `prog-mode` and `text-mode` when `dotspacemacs-line-numbers` is set to `t` (See the [document](https://develop.spacemacs.org/doc/DOCUMENTATION.html#global-line-numbers)). However, due to this problem, Spacemacs does not display line numbers for `coq-mode` by default.

## Solution

It is better to define `'coq--parent-mode` as an alias:

```elisp
(defalias 'coq--parent-mode
  (if coq-use-pg 'proof-mode 'prog-mode))
```

With this definition, `derived-mode-p` can detect that `coq-mode` is a sub-mode of `prog-mode`:

```elisp
;; after editing
;; when you are in coq buffer
(derived-mode-p 'prog-mode)
; => 'prog-mode
```

And Spacemacs will automatically display line numbers for coq buffer when setting `dotspacemacs-line-numbers` to `t`.