### PR TITLE
simple-tests/omit_test: fix Coq sources for 8.19

### DIFF
--- a/ci/simple-tests/omit_test.v
+++ b/ci/simple-tests/omit_test.v
@@ -44,7 +44,7 @@ Qed.
 Section let_test.
 
   Let never_omit_let : 1 + 1 = 2.
-  Proof using.
+  Proof.
     (* automatic test marker 7 *)
     auto.
   Qed.


### PR DESCRIPTION
8.19 does not tolerate Proof using after let. Until now this problem was hidden by the two expected fails.