### PR TITLE
Avoid evaluating void variables

### DIFF
--- a/lib/unicode-tokens.el
+++ b/lib/unicode-tokens.el
@@ -223,12 +223,13 @@ if it is bound; it should be the name of a variable."
     (setq unicode-tokens-shortcut-replacement-alist
 	  unicode-tokens-shortcut-alist))
   (unless unicode-tokens-tokens-customizable-variables
+    (let ((f (lambda (sym) (when (boundp sym) (symbol-value sym)))))
     (setq unicode-tokens-tokens-customizable-variables
 	  (list
 	   (list "Token Map"
-		 (symbol-value (unicode-tokens-config-var 'token-symbol-map)))
+		 (funcall f (unicode-tokens-config-var 'token-symbol-map)))
 	   (list "Shortcut List"
-		 (symbol-value (unicode-tokens-config-var 'shortcut-alist)))))))
+		 (funcall f (unicode-tokens-config-var 'shortcut-alist))))))))
 
 ;;
 ;; Variables set in the mode


### PR DESCRIPTION
The last `unless` case of `unicode-tokens-copy-configuration-variables` tries to evaluate variables which may be undefined via `symbol-value`, which leads to an error. This commit adds a check to make sure the variables are only accessed if bound.

How this ever worked without errors I don't know...