### PR TITLE
Add features: use goal count information printed at top of goals buffer in modeline, clear the goal window when proof is skipped (abort, admitted...).

### DIFF
--- a/generic/pg-goals.el
+++ b/generic/pg-goals.el
@@ -107,8 +107,10 @@ so the response buffer should not be cleared."
       (bufhist-checkpoint-and-erase))
 
     ;; Only display if string is non-empty.
-    (unless (string-equal string "")
-      (funcall pg-insert-text-function string))
+    (when (not (string-equal string ""))
+      (funcall pg-insert-text-function string)
+      (when (string-equal proof-assistant "Coq")
+        (coq-parse-goals-info string)))
 
     (setq buffer-read-only t)
     (set-buffer-modified-p nil)

--- a/generic/proof-script.el
+++ b/generic/proof-script.el
@@ -1486,6 +1486,8 @@ Besides stuff that is not yet documented here, this function
   and sections.
 - enters some commands and their spans in some database (with for
   me unknown purpose)"
+  (when (string-equal proof-assistant "Coq")
+    (reset-goals-modeline)) ; Erase goal modeline when a proof is closed
   (unless (or (eq proof-shell-proof-completed 1)
 	      ;; (eq proof-assistant-symbol 'isar)
 	      )


### PR DESCRIPTION
In response to issues #605  and #168, I moved the information of current goal to the *goals* buffer modeline (to save some space and visibility basically), and cleared the *goals* buffer when encountering skip proof tactics like Abort. or Admitted. in Coq.