### PR TITLE
Reduce splash time to 1s.

### DIFF
--- a/generic/proof-splash.el
+++ b/generic/proof-splash.el
@@ -42,7 +42,7 @@
   :type 'boolean
   :group 'proof-user-options)
 
-(defcustom proof-splash-time 8
+(defcustom proof-splash-time 1
   "Minimum number of seconds to display splash screen for.
 The splash screen may be displayed for a wee while longer than
 this, depending on how long it takes the machine to initialise


### PR DESCRIPTION
The idea is that this splash screen annoys everyone, even in its new manga-style form.

I would even consider removing it completely but at least let us not have it last for 8 seconds by default.