### PR TITLE
fix(coq.el): (setq proof-shell-strip-crs-from-input nil)

### DIFF
--- a/coq/coq.el
+++ b/coq/coq.el
@@ -1984,6 +1984,10 @@ at `proof-assistant-settings-cmds' evaluation time.")
    proof-shell-interrupt-regexp coq-interrupt-regexp
    proof-shell-assumption-regexp coq-id
    proof-shell-theorem-dependency-list-regexp coq-shell-theorem-dependency-list-regexp
+   ;; CRs now can and should be preserved (to support String-related theories),
+   ;; see also this GitHub issue: https://github.com/ProofGeneral/PG/issues/773
+   proof-shell-strip-crs-from-input nil
+
    pg-subterm-first-special-char ?\360
    ;; The next three represent path annotation information
    pg-subterm-start-char ?\372          ; not done


### PR DESCRIPTION
Related: https://github.com/ProofGeneral/PG/issues/773

@hendriktews do you agree that we merge this ? (if the CI passes, of course)