### PR TITLE
Change _CoqProject separator settings

### DIFF
--- a/coq/coq-indent.el
+++ b/coq/coq-indent.el
@@ -264,11 +264,6 @@ if found, to (point-max) otherwise.  Return t if found, nil otherwise."
           (setq nbopen (- nbopen 1))))
       (= nbopen 0))))
 
-(defun coq-looking-at-comment ()
-  "Return non-nil if point is inside a comment."
-  (or (proof-inside-comment (point))
-      (proof-inside-comment (+ 1 (point)))))
-
 (defun coq-find-comment-start ()
   "Go to the current comment start.
 If inside nested comments, go to the start of the outer most comment.

--- a/coq/coq-system.el
+++ b/coq/coq-system.el
@@ -550,7 +550,7 @@ alreadyopen is t if buffer already existed."
 				  (find-file-noselect projectfile t t))))
 	  (list projectbuffer projectbufferalreadyopen))))))
 
-(defconst coq--project-file-separator "[\r\n[:space:]]+")
+(defconst coq--project-file-separator "[\r\t\n[:space:]]+")
 
 (defconst coq--makefile-switch-arities
   '(("-R" . 2)


### PR DESCRIPTION
According to the code of coq_makefile, ~`\r` is not considered white-space in _CoqProject. But `\t` is.~ `\t` is considered white-space.
Source: https://github.com/coq/coq/blob/a7f51315db5d70888af3b96a579eb799a2b45ca9/lib/coqProject_file.ml#L84

The second commit of this PR removes a duplicate function definition.