### PR TITLE
Fix #757 indentation of "\in"

### DIFF
--- a/ci/test-indent/indent-backslash-ops.v
+++ b/ci/test-indent/indent-backslash-ops.v
@@ -1,0 +1,23 @@
+Require Import mathcomp.ssreflect.ssrbool.
+
+Definition xx := nat.
+Module foo.
+  (* from PG issue #757 *)
+  Lemma test:
+    forall a : nat,
+      a \in [::] ->  (* "\in" should be detected as one token *)
+      False.
+  Proof.
+  Abort.
+  Qed.
+
+  Lemma test2:
+    forall a : nat,
+      a \in  (* "\in" should be detected as one token *)
+        [::] ->
+      False.
+  Proof.
+  Abort.
+  Qed.
+End foo.
+


### PR DESCRIPTION
The lexer now glues a "\" to an immediately following word if it is itself preceded by a space.

Note that for really good indentation you should try to add something like this to your configuration:

(setq coq-smie-user-tokens '(("\\in" . "=")))

to tell the indentation grammar that \in has the same precedence as "=".