### PR TITLE
proof-shell: Don't ask about killing the proof assistant on exit

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,11 @@ the Git ChangeLog, the GitHub repo https://github.com/ProofGeneral/PG
     changes below for more details.
 *** New command `proof-check-annotate' to annotate all failing proofs
     with FAIL comments.
+*** Improve splash screen, add menu entry to permanently disable it
+    (Proof-General -> Quick Options -> Display -> Disable Splash Screen),
+    reduce splash screen time to make it less annoying
+*** Don't ask about killing the proof assistant when quitting Emacs and
+    thereby the Proof General session.
 
 ** Coq changes
 *** support Coq 8.19

--- a/generic/proof-shell.el
+++ b/generic/proof-shell.el
@@ -479,6 +479,12 @@ process command."
 	(erase-buffer)
 	(proof-shell-set-text-representation)
 
+        ;; If the user quits Emacs together with the Proof General
+        ;; session, it's clear that the proof assistant needs to be
+        ;; killed - don't ask.
+        (set-process-query-on-exit-flag
+         (get-buffer-process proof-shell-buffer) nil)
+
 	;; Initialise associated buffers
 	(with-current-buffer proof-response-buffer
 	  (erase-buffer)


### PR DESCRIPTION
This PR is only about the commit in the title. To avoid conflicts, it builds on PR #791.

I have disabled this silly question about killing Coq when quitting Emacs decades ago already. IMO we don't need a user option to control this behavior.