### PR TITLE
coq/generic: display empty strings in diagnostic messages

### DIFF
--- a/coq/coq-par-compile.el
+++ b/coq/coq-par-compile.el
@@ -969,7 +969,8 @@ file to be deleted when the process does not finish successfully."
     (when coq--debug-auto-compilation
       (message "%s %s: start %s %s in %s"
 	       (get job 'name) process-name
-	       command (mapconcat #'identity arguments " ")
+	       command
+               (mapconcat (lambda (a) (concat "\"" a "\"")) arguments " ")
 	       default-directory))
     (condition-case err
 	;; If the command is wrong, start-process aborts with an

--- a/generic/proof-shell.el
+++ b/generic/proof-shell.el
@@ -400,7 +400,9 @@ process command."
 		  (append (split-string proof-rsh-command)
 			  prog-name-list1)
 		prog-name-list1))
-	     (prog-command-line (mapconcat 'identity prog-name-list " "))
+	     (prog-command-line
+              (mapconcat (lambda (arg) (concat "\"" arg "\""))
+                         prog-name-list " "))
 
 	     (process-connection-type
 	      proof-shell-process-connection-type)


### PR DESCRIPTION
... for the argument lists of background processes started by PG