### PR TITLE
Fix low level code to find the start of a command.

### DIFF
--- a/ci/test-indent/indent-tac.v
+++ b/ci/test-indent/indent-tac.v
@@ -269,6 +269,19 @@ Module M1.
         { auto.
         }
       }
+      1:{
+        destruct n.
+        2:{ auto.
+        }
+        { auto. }
+      }
+      {
+        destruct n.
+        2:{
+          auto. }
+        { auto.
+        }
+      }
     Qed.
   End M2.
 End M1.

--- a/coq/coq-indent.el
+++ b/coq/coq-indent.el
@@ -216,10 +216,10 @@ position."
     (coq-find-previous-endcmd)
     (while (not something-found)
       (forward-comment (point-max))
-      (if (and (looking-at "\\({\\|}\\|\\++\\|\\*+\\|-+\\)")
+      (if (and (looking-at "\\(?1:{\\|}\\|\\++\\|\\*+\\|-+\\|[0-9]+\\s-*:{\\)")
                (< (point) p) ;; if we are after the starting point then anything is the start of the current command, even "#" or ".".
                )
-          (forward-char 1)
+          (goto-char (match-end 1))
         (setq something-found t))))
   (point))
 

--- a/coq/coq.el
+++ b/coq/coq.el
@@ -2500,13 +2500,15 @@ tacitcs like destruct and induction reuse hypothesis names by
 default, which makes the detection of new hypothesis incorrect.
 the hack consists in adding the \"!\" modifier on the argument
 destructed, so that it is left in the goal and the name cannot be
-reused.  We also had a \"clear\" at the end of the tactic so that
+reused.  We also add a \"clear\" at the end of the tactic so that
 the whole tactic behaves correctly.
 Warning: this makes the error messages (and location) wrong.")
 
 (defun coq-hack-cmd-for-infoH (s)
   "return the tactic S hacked with infoH tactical."
   (cond
+   ;; We cannot rebuild the sub-patterns from the final goal, so ';' is not
+   ;; supported. Only single tactics like destruct.
    ((string-match ";" s) s) ;; composed tactic cannot be treated
    ((string-match coq-auto-as-hack-hyp-name-regex s)
     (concat "infoH " (match-string 1 s) " (" (match-string 2 s) ")."))
@@ -2707,6 +2709,7 @@ Used for automatic insertion of \"Proof using\" annotations.")
   (interactive)
   (save-excursion
     (goto-char (proof-unprocessed-begin))
+    (forward-char 1)
     (coq-find-real-start)
     (let* ((pt (point))
            (_ (coq-script-parse-cmdend-forward))


### PR DESCRIPTION
A small bug in the code for finding the real start of a command. It was wrong in the case of focus commands `3:{`.

The side effects of this should be almost invisible. I detected the bug when debugging experimental stuff.