### PR TITLE
Fix problems with error on the first command of a file.

### DIFF
--- a/ci/test_error_loc_fst_cmd.v
+++ b/ci/test_error_loc_fst_cmd.v
@@ -1,0 +1,4 @@
+Definition foo:= bar. (*after-error*)
+
+Definition foobar := nat.
+

--- a/coq/coq-indent.el
+++ b/coq/coq-indent.el
@@ -208,7 +208,8 @@ position."
   (while (coq-looking-at-comment) ;; we are looking for ". " so this is enough
     (re-search-backward (concat "\\(?2:" coq-simple-cmd-ender-prefix-regexp-backward "\\)\\.\\s-") (point-min) 'dummy))
   ;; unless we reached point-min, jump over the "."
-  (when (match-end 2) (goto-char (match-end 2)) (forward-char 1))
+  (when (and (not (eq (point) (point-min))) (match-end 2))
+    (goto-char (match-end 2)) (forward-char 1))
   (point))
 
 (defun coq-find-start-of-cmd ()


### PR DESCRIPTION
Small annoying bug seemingly squashed.

I think this solves #814 and the fact that the error was not correctly located.