### PR TITLE
generic: reset proof-shell-delayed-output-{start,end,flags} regularly

### DIFF
--- a/ci/simple-tests/coq-test-goals-present.el
+++ b/ci/simple-tests/coq-test-goals-present.el
@@ -174,7 +174,7 @@ Used in `check-response-present' for all `response-buffer-visible-*' tests.")
     (* marker A *)
   Qed.
 "
-  "Coq source for ert-deftest error-message-visible-at-proof-end")
+  "Coq source for ert-deftest's error-message-visible-at-qed-*")
 
 
 ;;; utility functions
@@ -490,7 +490,6 @@ variable and check that the error message is displayed."
         (kill-buffer buffer)))))
 
 (ert-deftest error-message-visible-at-qed-complete-script ()
-  :expected-result :failed
   "Check that the error message is present at the end of the proof.
 Run a complete script that provokes an error at Qed about a not declared
 section variable and check that the error message is displayed."

--- a/doc/PG-adapting.texi
+++ b/doc/PG-adapting.texi
@@ -4289,16 +4289,19 @@ to examine @samp{@code{proof-shell-last-output}}.
 @c TEXI DOCSTRING MAGIC: proof-shell-delayed-output-start
 @defvar proof-shell-delayed-output-start 
 A record of the start of the previous output in the shell buffer.@*
-The previous output is held back for processing at end of queue.
+The previous output is held back for processing at end of queue. Reset
+in @samp{@code{proof-shell-filter}}, i.e., when subsequent output arrives.
 @end defvar
 @c TEXI DOCSTRING MAGIC: proof-shell-delayed-output-end
 @defvar proof-shell-delayed-output-end 
 A record of the start of the previous output in the shell buffer.@*
-The previous output is held back for processing at end of queue.
+The previous output is held back for processing at end of queue. Reset
+in @samp{@code{proof-shell-filter}}, i.e., when subsequent output arrives.
 @end defvar
 @c TEXI DOCSTRING MAGIC: proof-shell-delayed-output-flags
 @defvar proof-shell-delayed-output-flags 
-A copy of the @samp{@code{proof-action-list}} flags for @samp{proof-shell-delayed-output}.
+A copy of the @samp{@code{proof-action-list}} flags for @samp{proof-shell-delayed-output}.@*
+Reset in @samp{@code{proof-shell-filter}}, i.e., when subsequent output arrives.
 @end defvar
 @vindex proof-action-list
 


### PR DESCRIPTION
Before this change, proof-shell-delayed-output-{start,end,flags} were only set inside proof-shell-filter-manage-output but never reset. Setting these variables happens immediately before the call to proof-shell-exec-loop, i.e., after processing urgent messages in proof-shell-process-urgent-messages and after handling errors in proof-shell-handle-immediate-output. Therefore urgent and error messages were processed with stale values in
proof-shell-delayed-output-{start,end,flags} that corresponded to the previous piece of processed output. This resulted at least in the following odd behavior:
- On error, the previous output was processed again with proof-shell-handle-delayed-output and the error was often classified as goals in proof-shell-last-output-kind.
- On error, both proof-shell-handle-delayed-output-hook and proof-shell-handle-error-or-interrupt-hook were run, resulting in two calls to coq-show-goals-inside-proof, which in turn usually resulted in two Show commands after an error for Coq/Rocq, but sometimes also no Show command, because of the stale flags.

Resetting proof-shell-delayed-output-{start,end,flags} at the begin of proof-shell-filter fixes these points, even though they have not been identified as problematic until now.