### PR TITLE
CI: add new tests for error messages at Qed

### DIFF
--- a/ci/simple-tests/README.md
+++ b/ci/simple-tests/README.md
@@ -13,8 +13,9 @@ coq-test-par-job-needs-compilation-quick
 coq-test-prelude-correct
 : test that the Proof General prelude is correct
 coq-test-goals-present
-: test that Proof General shows goals correctly in various
-  situations
+: Test that Proof General shows goals correctly in various situations.
+  Test also that in other situations the response buffer contains the
+  right output and is visible in two-pane mode.
 coq-test-three-window
 : Test three-pane mode for different frame sizes, including ones that
   are too small for three windows.


### PR DESCRIPTION
When running silent, the error about a missing section variable is not always shown correctly.