### PR TITLE
CI: add new test for extending/retracting with huge goals

### DIFF
--- a/ci/simple-tests/README.md
+++ b/ci/simple-tests/README.md
@@ -13,9 +13,10 @@ coq-test-par-job-needs-compilation-quick
 coq-test-prelude-correct
 : test that the Proof General prelude is correct
 coq-test-goals-present
-: Test that Proof General shows goals correctly in various situations.
-  Test also that in other situations the response buffer contains the
-  right output and is visible in two-pane mode.
+: Test that Proof General shows goals and responses correctly in
+  various situations and that the expected thing is visible in
+  two-pane mode. Test also that extending and retracting works as
+  expected when huge goals cause a delay.
 coq-test-three-window
 : Test three-pane mode for different frame sizes, including ones that
   are too small for three windows.


### PR DESCRIPTION
Extending the queue while Coq is still busy with printing the previous goal gives an internal error, see #836.