### PR TITLE
Rocq: prefer Rocq binaries over Coq ones

### DIFF
--- a/coq/coq-mode.el
+++ b/coq/coq-mode.el
@@ -43,7 +43,7 @@
       default))
 
 (defun coq-autodetect-progname ()
-  (coq-detect-prog-gen "coqtop" "rocq"))
+  (coq-detect-prog-gen "rocq" "coqtop"))
 
 (defcustom coq-prog-name (coq-autodetect-progname)
   "Name of program to run as Coq.


### PR DESCRIPTION
Before this change Proof General ignores an Opam Roqc installation if there is a system wide Coq installation.