### PR TITLE
feat(coq): insert named goal selectors

### DIFF
--- a/coq/coq.el
+++ b/coq/coq.el
@@ -2924,18 +2924,7 @@ Also insert holes at insertion positions."
       (unless (proof-string-match coq-error-regexp match)
         (let ((start (point)))
           (insert match)
-          (indent-region start (point) nil)
-          (let ((n (holes-replace-string-by-holes-backward start)))
-            (pcase n
-	      (0 nil)                   ; no hole, stay here.
-	      (1
-	       (goto-char start)
-	       (holes-set-point-next-hole-destroy)) ; if only one hole, go to it.
-	      (_
-	       (goto-char start)
-	       (message
-                (substitute-command-keys
-                 "\\[holes-set-point-next-hole-destroy] to jump to active hole.  \\[holes-short-doc] to see holes doc."))))))))))
+          (holes-replace-string-by-holes-backward-jump start))))))
 
 (defun coq-insert-solve-tactic ()
   "Ask for a closing tactic name, with completion, and insert at point.

--- a/coq/coq.el
+++ b/coq/coq.el
@@ -2982,6 +2982,7 @@ Completion is on a quasi-exhaustive list of Coq tacticals."
 ;; Insertion commands
 (define-key coq-keymap [(control ?i)]  #'coq-insert-intros)
 (define-key coq-keymap [(control ?m)]  #'coq-insert-match)
+(define-key coq-keymap [(control ?g)]  #'coq-insert-named-goal-selectors)
 (define-key coq-keymap [(control ?\()] #'coq-insert-section-or-module)
 (define-key coq-keymap [(control ?\))] #'coq-end-Section)
 (define-key coq-keymap [(control ?t)]  #'coq-insert-tactic)

--- a/lib/holes.el
+++ b/lib/holes.el
@@ -632,7 +632,7 @@ If ALWAYSJUMP is non-nil, jump to the first hole even if more than one."
        (when alwaysjump (holes-set-point-next-hole-destroy))
        (unless (active-minibuffer-window) ; otherwise minibuffer gets hidden
 	 (message (substitute-command-keys
-		   "\\[holes-set-point-next-hole-destroy] to jump to active hole.  \\[holes-short-doc] to see holes doc.")))))))
+		   "\\[holes-set-point-next-hole-destroy] to jump to active hole.  \\[holes-show-doc] to see holes doc.")))))))
 
 
 ;;;###autoload

--- a/lib/holes.el
+++ b/lib/holes.el
@@ -620,7 +620,7 @@ The LIMIT argument bounds the search; it is a buffer position.
 \"#\" and \"@{..}\" between this positions will become holes.
 If NOINDENT is non-nil, skip the indenting step.
 If ALWAYSJUMP is non-nil, jump to the first hole even if more than one."
-  (unless noindent (save-excursion (indent-region pos (point) nil)))
+  (unless noindent (save-excursion (indent-region pos (point))))
   (let ((n (holes-replace-string-by-holes-backward pos)))
     (pcase n
       (`0 nil)				; no hole, stay here.


### PR DESCRIPTION
This PR implements the `coq-insert-named-goal-selectors` function that automatically generates named goal selectors (of the form `[name]: tac.`)  for each open named goal. I bound it to `C-c C-a C-g` by default.

The implementation is based on the output of `Show Existentials`, and notably checks for the absence of `(only printing)` in the output to distinguish focusable goal names from unfocusable goals (see https://github.com/rocq-prover/rocq/pull/20809).

This feature is mainly intended to be used in conjunction with [automatically named goals](https://rocq-prover.org/doc/master/refman/proofs/writing-proofs/proof-mode.html#rocq:flag.Generate-Goal-Names) in Rocq 9.2.

Here's a demo:
![demo](https://github.com/user-attachments/assets/4efca201-242d-40b0-b254-4f98b4f5ca12)
