### PR TITLE
Add support for 'repeat-mode'

### DIFF
--- a/coq/coq.el
+++ b/coq/coq.el
@@ -961,7 +961,7 @@ Otherwise propose identifier at point if any."
            (t (coq-id-or-notation-at-point)))))
     (read-string
      (if guess (concat s " (default " guess "): ") (concat s ": "))
-     nil 'proof-minibuffer-history guess)))
+     nil 'proof-minibuffer-history guess t)))
 
 
 (defun coq-ask-do (ask do &optional dontguess postformatcmd wait)

--- a/generic/proof-menu.el
+++ b/generic/proof-menu.el
@@ -143,6 +143,15 @@ without adjusting window layout."
   ;; NB: C-c ` is next-error in universal-keys
   (proof-define-keys map proof-universal-keys))
 
+(defvar proof-repeat-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-n") #'proof-assert-next-command-interactive)
+    (define-key map (kbd "C-u") #'proof-undo-last-successful-command)
+    map))
+
+;; support for `repeat-mode' (≥Emacs 28)
+(put #'proof-assert-next-command-interactive 'repeat-map 'proof-repeat-map)
+(put #'proof-undo-last-successful-command 'repeat-map 'proof-repeat-map)
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Emacs has a `repeat-mode` that you can use to avoid typing in the prefix of a keychord for related commands.  Eg. when enabled you can just press `o` after `C-x o` to switch to then next window.  This adds similar support for at least two commands that I find useful when loading and undoing commands in a Rocq buffer.