### PR TITLE
Fix `coq-insert-named-goal-selectors` wrong type argument

### DIFF
--- a/coq/coq-abbrev.el
+++ b/coq/coq-abbrev.el
@@ -111,7 +111,9 @@ start."
   (when snippet
     (if (and coq-use-yasnippet (fboundp 'yas-expand))
         (yas-expand-snippet (coq-yas-snippet-from-db snippet))
-      (insert (coq-simple-abbrev-from-db snippet)))))
+      (let ((start (point)))
+        (insert (coq-simple-abbrev-from-db snippet))
+        (indent-region start (point))))))
 
         ;; (if (fboundp 'with-undo-amalgamate) ;; emacs > 29.1
         ;;     (with-undo-amalgamate (insert abbr) (yas-expand))

--- a/coq/coq.el
+++ b/coq/coq.el
@@ -2938,13 +2938,10 @@ Goals that are marked as \"only printing\" are ignored."
              ;; NOTE: Adding braces would be great, but it messes up indentation.
              (format-selector (lambda (name) (format "[%s]: #." name)))
              (goal-selectors (cl-mapcar format-selector goal-names))
-             (snippet (string-join goal-selectors "\n"))
-             (snippet (coq-insert-template snippet)))
-        (message "%s" goal-names)
+             (snippet (string-join goal-selectors "\n")))
         (if (equal goal-selectors nil)
             (error "Couldn't find any named goals")
-          (let ((start (point)))
-            (if coq-use-yasnippet (yas-expand-snippet snippet) (insert snippet))))))))
+          (coq-insert-template snippet))))))
 
 (defun coq-insert-match ()
   "Insert a match expression from a type name by Show Match.


### PR DESCRIPTION
This PR fixes `coq-insert-named-goal-selectors` after the move to yasnippet, as it currently outputs "Wrong type argument: char-or-string-p, nil" in the echo area. It also fixes the missing indentation when not using yasnippet.