### PR TITLE
Allow EasyCrypt lemma names to begin with `_`.

### DIFF
--- a/easycrypt/easycrypt-syntax.el
+++ b/easycrypt/easycrypt-syntax.el
@@ -49,7 +49,7 @@
 
 (defconst easycrypt-goal-command-regexp
   (concat "^\\(?:local\\s-+\\)?\\(?:" (proof-ids-to-regexp easycrypt-keywords-proof-goal) "\\)"
-          "\\s-+\\(?:nosmt\\s-+\\)?\\(\\sw+\\)"))
+          "\\s-+\\([[:word:]_]\\)"))
 
 (defun easycrypt-save-command-p (span str)
   "Decide whether argument is a [save|qed] command or not."


### PR DESCRIPTION
Fix the regular expression `easycrypt-goal-command-regexp` to take out the `nosmt` option (which is no longer EasyCrypt syntax) and allow lemma names to begin with `_`. Note
that the end of this regular expression must only match the *beginning* of a lemma name,
not the whole name. (Without this fix, it was impossible to undo a lemma with such a name.)