### PR TITLE
Fix #882 (inconsistent indentation for `Variant`)

### DIFF
--- a/coq/coq-smie.el
+++ b/coq/coq-smie.el
@@ -596,7 +596,7 @@ The point should be at the beginning of the command name."
   (let* (;; (orig (point))
          (cmdstrt (save-excursion (coq-find-real-start)))
          (corresp (coq-smie-search-token-backward
-		   '("let" "Inductive" "CoInductive" "{|" "." "with" "Module" "where"
+		   '("let" "Inductive" "CoInductive" "Variant" "{|" "." "with" "Module" "where"
                      "Equations")
 		   cmdstrt '((("let" "with") . ":=")))))
     (cond


### PR DESCRIPTION
Hey,

This should fix #882. 

The backward search was not looking for `"Variant"`, so `corresp` would never be `"Variant"`, and so the line `((member corresp '("Inductive" "CoInductive" "Variant")) ":= inductive")` would never be triggered. 

Thanks a lot for your time!